### PR TITLE
Moved patches from GDrive to Git repo

### DIFF
--- a/custompatches/0001-01-fsync-unix-staging.patch
+++ b/custompatches/0001-01-fsync-unix-staging.patch
@@ -1,0 +1,3763 @@
+From 1d3dadfd7707ac176b67b50a0dc573f799778836 Mon Sep 17 00:00:00 2001
+From: Tk-Glitch <ti3nou@gmail.com>
+Date: Fri, 16 Oct 2020 20:53:31 +0200
+Subject: Fsync rebased 5.13+ staging
+
+
+diff --git a/dlls/ntdll/Makefile.in b/dlls/ntdll/Makefile.in
+index c96a62ae006..a9be561d87a 100644
+--- a/dlls/ntdll/Makefile.in
++++ b/dlls/ntdll/Makefile.in
+@@ -48,6 +48,7 @@ C_SRCS = \
+ 	unix/env.c \
+ 	unix/esync.c \
+ 	unix/file.c \
++	unix/fsync.c \
+ 	unix/loader.c \
+ 	unix/process.c \
+ 	unix/registry.c \
+diff --git a/dlls/ntdll/unix/esync.c b/dlls/ntdll/unix/esync.c
+index ed801c71991..ac0326b1aba 100644
+--- a/dlls/ntdll/unix/esync.c
++++ b/dlls/ntdll/unix/esync.c
+@@ -57,6 +57,7 @@
+ 
+ #include "unix_private.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(esync);
+ 
+@@ -66,7 +67,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC"));
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
+ 
+     return do_esync_cached;
+ #else
+@@ -867,7 +868,7 @@ static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEA
+             return ret;
+     }
+ 
+-    if (objs[count - 1] && objs[count - 1]->type == ESYNC_QUEUE)
++    if (count && objs[count - 1] && objs[count - 1]->type == ESYNC_QUEUE)
+         msgwait = TRUE;
+ 
+     if (has_esync && has_server)
+@@ -896,7 +897,7 @@ static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEA
+         }
+     }
+ 
+-    if (wait_any || count == 1)
++    if (wait_any || count <= 1)
+     {
+         /* Try to check objects now, so we can obviate poll() at least. */
+         for (i = 0; i < count; i++)
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+new file mode 100644
+index 00000000000..5012425b95a
+--- /dev/null
++++ b/dlls/ntdll/unix/fsync.c
+@@ -0,0 +1,1267 @@
++/*
++ * futex-based synchronization objects
++ *
++ * Copyright (C) 2018 Zebediah Figura
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
++ */
++
++#if 0
++#pragma makedep unix
++#endif
++
++#include "config.h"
++
++#include <assert.h>
++#include <errno.h>
++#include <fcntl.h>
++#include <limits.h>
++#include <stdarg.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <sys/mman.h>
++#ifdef HAVE_SYS_STAT_H
++# include <sys/stat.h>
++#endif
++#ifdef HAVE_SYS_SYSCALL_H
++# include <sys/syscall.h>
++#endif
++#include <unistd.h>
++
++#include "ntstatus.h"
++#define WIN32_NO_STATUS
++#define NONAMELESSUNION
++#include "windef.h"
++#include "winternl.h"
++#include "wine/debug.h"
++#include "wine/server.h"
++
++#include "unix_private.h"
++#include "fsync.h"
++
++WINE_DEFAULT_DEBUG_CHANNEL(fsync);
++
++#include "pshpack4.h"
++struct futex_wait_block
++{
++    int *addr;
++#if __SIZEOF_POINTER__ == 4
++    int pad;
++#endif
++    int val;
++    int bitset;
++};
++#include "poppack.h"
++
++static inline void small_pause(void)
++{
++#if defined(__i386__) || defined(__x86_64__)
++    __asm__ __volatile__( "rep;nop" : : : "memory" );
++#else
++    __asm__ __volatile__( "" : : : "memory" );
++#endif
++}
++
++static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
++        int count, const struct timespec *timeout )
++{
++    return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
++}
++
++static inline int futex_wake( int *addr, int val )
++{
++    return syscall( __NR_futex, addr, 1, val, NULL, 0, 0 );
++}
++
++static inline int futex_wait( int *addr, int val, struct timespec *timeout )
++{
++    return syscall( __NR_futex, addr, 0, val, timeout, 0, 0 );
++}
++
++static unsigned int spincount = 100;
++
++int do_fsync(void)
++{
++#ifdef __linux__
++    static int do_fsync_cached = -1;
++
++    if (do_fsync_cached == -1)
++    {
++        static const struct timespec zero;
++        futex_wait_multiple( NULL, 0, &zero );
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        if (getenv("WINEFSYNC_SPINCOUNT"))
++            spincount = atoi(getenv("WINEFSYNC_SPINCOUNT"));
++    }
++
++    return do_fsync_cached;
++#else
++    static int once;
++    if (!once++)
++        FIXME("futexes not supported on this platform.\n");
++    return 0;
++#endif
++}
++
++struct fsync
++{
++    enum fsync_type type;
++    void *shm;              /* pointer to shm section */
++};
++
++struct semaphore
++{
++    int count;
++    int max;
++};
++C_ASSERT(sizeof(struct semaphore) == 8);
++
++struct event
++{
++    int signaled;
++    int unused;
++};
++C_ASSERT(sizeof(struct event) == 8);
++
++struct mutex
++{
++    int tid;
++    int count;  /* recursion count */
++};
++C_ASSERT(sizeof(struct mutex) == 8);
++
++static char shm_name[29];
++static int shm_fd;
++static void **shm_addrs;
++static int shm_addrs_size;  /* length of the allocated shm_addrs array */
++static long pagesize;
++
++static pthread_mutex_t shm_addrs_mutex = PTHREAD_MUTEX_INITIALIZER;
++
++static void *get_shm( unsigned int idx )
++{
++    int entry  = (idx * 8) / pagesize;
++    int offset = (idx * 8) % pagesize;
++    void *ret;
++
++    pthread_mutex_lock( &shm_addrs_mutex );
++
++    if (entry >= shm_addrs_size)
++    {
++        int new_size = max(shm_addrs_size * 2, entry + 1);
++
++        if (!(shm_addrs = realloc( shm_addrs, new_size * sizeof(shm_addrs[0]) )))
++            ERR("Failed to grow shm_addrs array to size %d.\n", shm_addrs_size);
++        memset( shm_addrs + shm_addrs_size, 0, (new_size - shm_addrs_size) * sizeof(shm_addrs[0]) );
++        shm_addrs_size = new_size;
++    }
++
++    if (!shm_addrs[entry])
++    {
++        void *addr = mmap( NULL, pagesize, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, entry * pagesize );
++        if (addr == (void *)-1)
++            ERR("Failed to map page %d (offset %#lx).\n", entry, entry * pagesize);
++
++        TRACE("Mapping page %d at %p.\n", entry, addr);
++
++        if (__sync_val_compare_and_swap( &shm_addrs[entry], 0, addr ))
++            munmap( addr, pagesize ); /* someone beat us to it */
++    }
++
++    ret = (void *)((unsigned long)shm_addrs[entry] + offset);
++
++    pthread_mutex_unlock( &shm_addrs_mutex );
++
++    return ret;
++}
++
++/* We'd like lookup to be fast. To that end, we use a static list indexed by handle.
++ * This is copied and adapted from the fd cache code. */
++
++#define FSYNC_LIST_BLOCK_SIZE  (65536 / sizeof(struct fsync))
++#define FSYNC_LIST_ENTRIES     256
++
++static struct fsync *fsync_list[FSYNC_LIST_ENTRIES];
++static struct fsync fsync_list_initial_block[FSYNC_LIST_BLOCK_SIZE];
++
++static inline UINT_PTR handle_to_index( HANDLE handle, UINT_PTR *entry )
++{
++    UINT_PTR idx = (((UINT_PTR)handle) >> 2) - 1;
++    *entry = idx / FSYNC_LIST_BLOCK_SIZE;
++    return idx % FSYNC_LIST_BLOCK_SIZE;
++}
++
++static struct fsync *add_to_list( HANDLE handle, enum fsync_type type, void *shm )
++{
++    UINT_PTR entry, idx = handle_to_index( handle, &entry );
++
++    if (entry >= FSYNC_LIST_ENTRIES)
++    {
++        FIXME( "too many allocated handles, not caching %p\n", handle );
++        return FALSE;
++    }
++
++    if (!fsync_list[entry])  /* do we need to allocate a new block of entries? */
++    {
++        if (!entry) fsync_list[0] = fsync_list_initial_block;
++        else
++        {
++            void *ptr = anon_mmap_alloc( FSYNC_LIST_BLOCK_SIZE * sizeof(struct fsync),
++                                         PROT_READ | PROT_WRITE );
++            if (ptr == MAP_FAILED) return FALSE;
++            fsync_list[entry] = ptr;
++        }
++    }
++
++    if (!__sync_val_compare_and_swap((int *)&fsync_list[entry][idx].type, 0, type ))
++        fsync_list[entry][idx].shm = shm;
++
++    return &fsync_list[entry][idx];
++}
++
++static struct fsync *get_cached_object( HANDLE handle )
++{
++    UINT_PTR entry, idx = handle_to_index( handle, &entry );
++
++    if (entry >= FSYNC_LIST_ENTRIES || !fsync_list[entry]) return NULL;
++    if (!fsync_list[entry][idx].type) return NULL;
++
++    return &fsync_list[entry][idx];
++}
++
++/* Gets an object. This is either a proper fsync object (i.e. an event,
++ * semaphore, etc. created using create_fsync) or a generic synchronizable
++ * server-side object which the server will signal (e.g. a process, thread,
++ * message queue, etc.) */
++static NTSTATUS get_object( HANDLE handle, struct fsync **obj )
++{
++    NTSTATUS ret = STATUS_SUCCESS;
++    unsigned int shm_idx = 0;
++    enum fsync_type type;
++
++    if ((*obj = get_cached_object( handle ))) return STATUS_SUCCESS;
++
++    if ((INT_PTR)handle < 0)
++    {
++        /* We can deal with pseudo-handles, but it's just easier this way */
++        return STATUS_NOT_IMPLEMENTED;
++    }
++
++    /* We need to try grabbing it from the server. */
++    SERVER_START_REQ( get_fsync_idx )
++    {
++        req->handle = wine_server_obj_handle( handle );
++        if (!(ret = wine_server_call( req )))
++        {
++            shm_idx = reply->shm_idx;
++            type    = reply->type;
++        }
++    }
++    SERVER_END_REQ;
++
++    if (ret)
++    {
++        WARN("Failed to retrieve shm index for handle %p, status %#x.\n", handle, ret);
++        *obj = NULL;
++        return ret;
++    }
++
++    TRACE("Got shm index %d for handle %p.\n", shm_idx, handle);
++
++    *obj = add_to_list( handle, type, get_shm( shm_idx ) );
++    return ret;
++}
++
++NTSTATUS fsync_close( HANDLE handle )
++{
++    UINT_PTR entry, idx = handle_to_index( handle, &entry );
++
++    TRACE("%p.\n", handle);
++
++    if (entry < FSYNC_LIST_ENTRIES && fsync_list[entry])
++    {
++        if (__atomic_exchange_n( &fsync_list[entry][idx].type, 0, __ATOMIC_SEQ_CST ))
++            return STATUS_SUCCESS;
++    }
++
++    return STATUS_INVALID_HANDLE;
++}
++
++static NTSTATUS create_fsync( enum fsync_type type, HANDLE *handle,
++    ACCESS_MASK access, const OBJECT_ATTRIBUTES *attr, int low, int high )
++{
++    NTSTATUS ret;
++    data_size_t len;
++    struct object_attributes *objattr;
++    unsigned int shm_idx;
++
++    if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
++
++    SERVER_START_REQ( create_fsync )
++    {
++        req->access = access;
++        req->low    = low;
++        req->high   = high;
++        req->type   = type;
++        wine_server_add_data( req, objattr, len );
++        ret = wine_server_call( req );
++        if (!ret || ret == STATUS_OBJECT_NAME_EXISTS)
++        {
++            *handle = wine_server_ptr_handle( reply->handle );
++            shm_idx = reply->shm_idx;
++            type    = reply->type;
++        }
++    }
++    SERVER_END_REQ;
++
++    if (!ret || ret == STATUS_OBJECT_NAME_EXISTS)
++    {
++        add_to_list( *handle, type, get_shm( shm_idx ));
++        TRACE("-> handle %p, shm index %d.\n", *handle, shm_idx);
++    }
++
++    free( objattr );
++    return ret;
++}
++
++static NTSTATUS open_fsync( enum fsync_type type, HANDLE *handle,
++    ACCESS_MASK access, const OBJECT_ATTRIBUTES *attr )
++{
++    NTSTATUS ret;
++    unsigned int shm_idx;
++
++    SERVER_START_REQ( open_fsync )
++    {
++        req->access     = access;
++        req->attributes = attr->Attributes;
++        req->rootdir    = wine_server_obj_handle( attr->RootDirectory );
++        req->type       = type;
++        if (attr->ObjectName)
++            wine_server_add_data( req, attr->ObjectName->Buffer, attr->ObjectName->Length );
++        if (!(ret = wine_server_call( req )))
++        {
++            *handle = wine_server_ptr_handle( reply->handle );
++            type = reply->type;
++            shm_idx = reply->shm_idx;
++        }
++    }
++    SERVER_END_REQ;
++
++    if (!ret)
++    {
++        add_to_list( *handle, type, get_shm( shm_idx ) );
++
++        TRACE("-> handle %p, shm index %u.\n", *handle, shm_idx);
++    }
++    return ret;
++}
++
++void fsync_init(void)
++{
++    struct stat st;
++
++    if (!do_fsync())
++    {
++        /* make sure the server isn't running with WINEFSYNC */
++        HANDLE handle;
++        NTSTATUS ret;
++
++        ret = create_fsync( 0, &handle, 0, NULL, 0, 0 );
++        if (ret != STATUS_NOT_IMPLEMENTED)
++        {
++            ERR("Server is running with WINEFSYNC but this process is not, please enable WINEFSYNC or restart wineserver.\n");
++            exit(1);
++        }
++
++        return;
++    }
++
++    if (stat( config_dir, &st ) == -1)
++        ERR("Cannot stat %s\n", config_dir);
++
++    if (st.st_ino != (unsigned long)st.st_ino)
++        sprintf( shm_name, "/wine-%lx%08lx-fsync", (unsigned long)((unsigned long long)st.st_ino >> 32), (unsigned long)st.st_ino );
++    else
++        sprintf( shm_name, "/wine-%lx-fsync", (unsigned long)st.st_ino );
++
++    if ((shm_fd = shm_open( shm_name, O_RDWR, 0644 )) == -1)
++    {
++        /* probably the server isn't running with WINEFSYNC, tell the user and bail */
++        if (errno == ENOENT)
++            ERR("Failed to open fsync shared memory file; make sure no stale wineserver instances are running without WINEFSYNC.\n");
++        else
++            ERR("Failed to initialize shared memory: %s\n", strerror( errno ));
++        exit(1);
++    }
++
++    pagesize = sysconf( _SC_PAGESIZE );
++
++    shm_addrs = calloc( 128, sizeof(shm_addrs[0]) );
++    shm_addrs_size = 128;
++}
++
++NTSTATUS fsync_create_semaphore( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max )
++{
++    TRACE("name %s, initial %d, max %d.\n",
++        attr ? debugstr_us(attr->ObjectName) : "<no name>", initial, max);
++
++    return create_fsync( FSYNC_SEMAPHORE, handle, access, attr, initial, max );
++}
++
++NTSTATUS fsync_open_semaphore( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr )
++{
++    TRACE("name %s.\n", debugstr_us(attr->ObjectName));
++
++    return open_fsync( FSYNC_SEMAPHORE, handle, access, attr );
++}
++
++NTSTATUS fsync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev )
++{
++    struct fsync *obj;
++    struct semaphore *semaphore;
++    ULONG current;
++    NTSTATUS ret;
++
++    TRACE("%p, %d, %p.\n", handle, count, prev);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    semaphore = obj->shm;
++
++    do
++    {
++        current = semaphore->count;
++        if (count + current > semaphore->max)
++            return STATUS_SEMAPHORE_LIMIT_EXCEEDED;
++    } while (__sync_val_compare_and_swap( &semaphore->count, current, count + current ) != current);
++
++    if (prev) *prev = current;
++
++    futex_wake( &semaphore->count, INT_MAX );
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS fsync_query_semaphore( HANDLE handle, void *info, ULONG *ret_len )
++{
++    struct fsync *obj;
++    struct semaphore *semaphore;
++    SEMAPHORE_BASIC_INFORMATION *out = info;
++    NTSTATUS ret;
++
++    TRACE("handle %p, info %p, ret_len %p.\n", handle, info, ret_len);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    semaphore = obj->shm;
++
++    out->CurrentCount = semaphore->count;
++    out->MaximumCount = semaphore->max;
++    if (ret_len) *ret_len = sizeof(*out);
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS fsync_create_event( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr, EVENT_TYPE event_type, BOOLEAN initial )
++{
++    enum fsync_type type = (event_type == SynchronizationEvent ? FSYNC_AUTO_EVENT : FSYNC_MANUAL_EVENT);
++
++    TRACE("name %s, %s-reset, initial %d.\n",
++        attr ? debugstr_us(attr->ObjectName) : "<no name>",
++        event_type == NotificationEvent ? "manual" : "auto", initial);
++
++    return create_fsync( type, handle, access, attr, initial, 0xdeadbeef );
++}
++
++NTSTATUS fsync_open_event( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr )
++{
++    TRACE("name %s.\n", debugstr_us(attr->ObjectName));
++
++    return open_fsync( FSYNC_AUTO_EVENT, handle, access, attr );
++}
++
++NTSTATUS fsync_set_event( HANDLE handle, LONG *prev )
++{
++    struct event *event;
++    struct fsync *obj;
++    LONG current;
++    NTSTATUS ret;
++
++    TRACE("%p.\n", handle);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    event = obj->shm;
++
++    if (!(current = __atomic_exchange_n( &event->signaled, 1, __ATOMIC_SEQ_CST )))
++        futex_wake( &event->signaled, INT_MAX );
++
++    if (prev) *prev = current;
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS fsync_reset_event( HANDLE handle, LONG *prev )
++{
++    struct event *event;
++    struct fsync *obj;
++    LONG current;
++    NTSTATUS ret;
++
++    TRACE("%p.\n", handle);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    event = obj->shm;
++
++    current = __atomic_exchange_n( &event->signaled, 0, __ATOMIC_SEQ_CST );
++
++    if (prev) *prev = current;
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS fsync_pulse_event( HANDLE handle, LONG *prev )
++{
++    struct event *event;
++    struct fsync *obj;
++    LONG current;
++    NTSTATUS ret;
++
++    TRACE("%p.\n", handle);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    event = obj->shm;
++
++    /* This isn't really correct; an application could miss the write.
++     * Unfortunately we can't really do much better. Fortunately this is rarely
++     * used (and publicly deprecated). */
++    if (!(current = __atomic_exchange_n( &event->signaled, 1, __ATOMIC_SEQ_CST )))
++        futex_wake( &event->signaled, INT_MAX );
++
++    /* Try to give other threads a chance to wake up. Hopefully erring on this
++     * side is the better thing to do... */
++    usleep(0);
++
++    __atomic_store_n( &event->signaled, 0, __ATOMIC_SEQ_CST );
++
++    if (prev) *prev = current;
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS fsync_query_event( HANDLE handle, void *info, ULONG *ret_len )
++{
++    struct event *event;
++    struct fsync *obj;
++    EVENT_BASIC_INFORMATION *out = info;
++    NTSTATUS ret;
++
++    TRACE("handle %p, info %p, ret_len %p.\n", handle, info, ret_len);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    event = obj->shm;
++
++    out->EventState = event->signaled;
++    out->EventType = (obj->type == FSYNC_AUTO_EVENT ? SynchronizationEvent : NotificationEvent);
++    if (ret_len) *ret_len = sizeof(*out);
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS fsync_create_mutex( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr, BOOLEAN initial )
++{
++    TRACE("name %s, initial %d.\n",
++        attr ? debugstr_us(attr->ObjectName) : "<no name>", initial);
++
++    return create_fsync( FSYNC_MUTEX, handle, access, attr,
++        initial ? GetCurrentThreadId() : 0, initial ? 1 : 0 );
++}
++
++NTSTATUS fsync_open_mutex( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr )
++{
++    TRACE("name %s.\n", debugstr_us(attr->ObjectName));
++
++    return open_fsync( FSYNC_MUTEX, handle, access, attr );
++}
++
++NTSTATUS fsync_release_mutex( HANDLE handle, LONG *prev )
++{
++    struct mutex *mutex;
++    struct fsync *obj;
++    NTSTATUS ret;
++
++    TRACE("%p, %p.\n", handle, prev);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    mutex = obj->shm;
++
++    if (mutex->tid != GetCurrentThreadId()) return STATUS_MUTANT_NOT_OWNED;
++
++    if (prev) *prev = mutex->count;
++
++    if (!--mutex->count)
++    {
++        __atomic_store_n( &mutex->tid, 0, __ATOMIC_SEQ_CST );
++        futex_wake( &mutex->tid, INT_MAX );
++    }
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS fsync_query_mutex( HANDLE handle, void *info, ULONG *ret_len )
++{
++    struct fsync *obj;
++    struct mutex *mutex;
++    MUTANT_BASIC_INFORMATION *out = info;
++    NTSTATUS ret;
++
++    TRACE("handle %p, info %p, ret_len %p.\n", handle, info, ret_len);
++
++    if ((ret = get_object( handle, &obj ))) return ret;
++    mutex = obj->shm;
++
++    out->CurrentCount = 1 - mutex->count;
++    out->OwnedByCaller = (mutex->tid == GetCurrentThreadId());
++    out->AbandonedState = (mutex->tid == ~0);
++    if (ret_len) *ret_len = sizeof(*out);
++
++    return STATUS_SUCCESS;
++}
++
++static LONGLONG update_timeout( ULONGLONG end )
++{
++    LARGE_INTEGER now;
++    LONGLONG timeleft;
++
++    NtQuerySystemTime( &now );
++    timeleft = end - now.QuadPart;
++    if (timeleft < 0) timeleft = 0;
++    return timeleft;
++}
++
++static NTSTATUS do_single_wait( int *addr, int val, ULONGLONG *end, BOOLEAN alertable )
++{
++    int ret;
++
++    if (alertable)
++    {
++        int *apc_futex = ntdll_get_thread_data()->fsync_apc_futex;
++        struct futex_wait_block futexes[2];
++
++        if (__atomic_load_n( apc_futex, __ATOMIC_SEQ_CST ))
++            return STATUS_USER_APC;
++
++        futexes[0].addr = addr;
++        futexes[0].val = val;
++        futexes[1].addr = apc_futex;
++        futexes[1].val = 0;
++#if __SIZEOF_POINTER__ == 4
++        futexes[0].pad = futexes[1].pad = 0;
++#endif
++        futexes[0].bitset = futexes[1].bitset = ~0;
++
++        if (end)
++        {
++            LONGLONG timeleft = update_timeout( *end );
++            struct timespec tmo_p;
++            tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
++            tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
++            ret = futex_wait_multiple( futexes, 2, &tmo_p );
++        }
++        else
++            ret = futex_wait_multiple( futexes, 2, NULL );
++
++        if (__atomic_load_n( apc_futex, __ATOMIC_SEQ_CST ))
++            return STATUS_USER_APC;
++    }
++    else
++    {
++        if (end)
++        {
++            LONGLONG timeleft = update_timeout( *end );
++            struct timespec tmo_p;
++            tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
++            tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
++            ret = futex_wait( addr, val, &tmo_p );
++        }
++        else
++            ret = futex_wait( addr, val, NULL );
++    }
++
++    if (!ret)
++        return 0;
++    else if (ret < 0 && errno == ETIMEDOUT)
++        return STATUS_TIMEOUT;
++    else
++        return STATUS_PENDING;
++}
++
++static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
++    BOOLEAN wait_any, BOOLEAN alertable, const LARGE_INTEGER *timeout )
++{
++    static const LARGE_INTEGER zero = {0};
++
++    struct futex_wait_block futexes[MAXIMUM_WAIT_OBJECTS + 1];
++    struct fsync *objs[MAXIMUM_WAIT_OBJECTS];
++    int has_fsync = 0, has_server = 0;
++    BOOL msgwait = FALSE;
++    int dummy_futex = 0;
++    unsigned int spin;
++    LONGLONG timeleft;
++    LARGE_INTEGER now;
++    DWORD waitcount;
++    ULONGLONG end;
++    int i, ret;
++
++    /* Grab the APC futex if we don't already have it. */
++    if (alertable && !ntdll_get_thread_data()->fsync_apc_futex)
++    {
++        unsigned int idx = 0;
++        SERVER_START_REQ( get_fsync_apc_idx )
++        {
++            if (!(ret = wine_server_call( req )))
++                idx = reply->shm_idx;
++        }
++        SERVER_END_REQ;
++
++        if (idx)
++        {
++            struct event *apc_event = get_shm( idx );
++            ntdll_get_thread_data()->fsync_apc_futex = &apc_event->signaled;
++        }
++    }
++
++    NtQuerySystemTime( &now );
++    if (timeout)
++    {
++        if (timeout->QuadPart == TIMEOUT_INFINITE)
++            timeout = NULL;
++        else if (timeout->QuadPart > 0)
++            end = timeout->QuadPart;
++        else
++            end = now.QuadPart - timeout->QuadPart;
++    }
++
++    for (i = 0; i < count; i++)
++    {
++        ret = get_object( handles[i], &objs[i] );
++        if (ret == STATUS_SUCCESS)
++            has_fsync = 1;
++        else if (ret == STATUS_NOT_IMPLEMENTED)
++            has_server = 1;
++        else
++            return ret;
++    }
++
++    if (count && objs[count - 1] && objs[count - 1]->type == FSYNC_QUEUE)
++        msgwait = TRUE;
++
++    if (has_fsync && has_server)
++        FIXME("Can't wait on fsync and server objects at the same time!\n");
++    else if (has_server)
++        return STATUS_NOT_IMPLEMENTED;
++
++    if (TRACE_ON(fsync))
++    {
++        TRACE("Waiting for %s of %d handles:", wait_any ? "any" : "all", count);
++        for (i = 0; i < count; i++)
++            TRACE(" %p", handles[i]);
++
++        if (msgwait)
++            TRACE(" or driver events");
++        if (alertable)
++            TRACE(", alertable");
++
++        if (!timeout)
++            TRACE(", timeout = INFINITE.\n");
++        else
++        {
++            timeleft = update_timeout( end );
++            TRACE(", timeout = %ld.%07ld sec.\n",
++                (long) (timeleft / TICKSPERSEC), (long) (timeleft % TICKSPERSEC));
++        }
++    }
++
++    if (wait_any || count <= 1)
++    {
++        while (1)
++        {
++            /* Try to grab anything. */
++
++            if (alertable)
++            {
++                /* We must check this first! The server may set an event that
++                 * we're waiting on, but we need to return STATUS_USER_APC. */
++                if (__atomic_load_n( ntdll_get_thread_data()->fsync_apc_futex, __ATOMIC_SEQ_CST ))
++                    goto userapc;
++            }
++
++            for (i = 0; i < count; i++)
++            {
++                struct fsync *obj = objs[i];
++
++                if (obj)
++                {
++                    if (!obj->type) /* gcc complains if we put this in the switch */
++                    {
++                        /* Someone probably closed an object while waiting on it. */
++                        WARN("Handle %p has type 0; was it closed?\n", handles[i]);
++                        return STATUS_INVALID_HANDLE;
++                    }
++
++                    switch (obj->type)
++                    {
++                    case FSYNC_SEMAPHORE:
++                    {
++                        struct semaphore *semaphore = obj->shm;
++                        int current;
++
++                        /* It would be a little clearer (and less error-prone)
++                         * to use a dedicated interlocked_dec_if_nonzero()
++                         * helper, but nesting loops like that is probably not
++                         * great for performance... */
++                        for (spin = 0; spin <= spincount || current; ++spin)
++                        {
++                            if ((current = __atomic_load_n( &semaphore->count, __ATOMIC_SEQ_CST ))
++                                    && __sync_val_compare_and_swap( &semaphore->count, current, current - 1 ) == current)
++                            {
++                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                                return i;
++                            }
++                            small_pause();
++                        }
++
++                        futexes[i].addr = &semaphore->count;
++                        futexes[i].val = 0;
++                        break;
++                    }
++                    case FSYNC_MUTEX:
++                    {
++                        struct mutex *mutex = obj->shm;
++                        int tid;
++
++                        if (mutex->tid == GetCurrentThreadId())
++                        {
++                            TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                            mutex->count++;
++                            return i;
++                        }
++
++                        for (spin = 0; spin <= spincount; ++spin)
++                        {
++                            if (!(tid = __sync_val_compare_and_swap( &mutex->tid, 0, GetCurrentThreadId() )))
++                            {
++                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                                mutex->count = 1;
++                                return i;
++                            }
++                            else if (tid == ~0 && (tid = __sync_val_compare_and_swap( &mutex->tid, ~0, GetCurrentThreadId() )) == ~0)
++                            {
++                                TRACE("Woken up by abandoned mutex %p [%d].\n", handles[i], i);
++                                mutex->count = 1;
++                                return STATUS_ABANDONED_WAIT_0 + i;
++                            }
++                            small_pause();
++                        }
++
++                        futexes[i].addr = &mutex->tid;
++                        futexes[i].val  = tid;
++                        break;
++                    }
++                    case FSYNC_AUTO_EVENT:
++                    case FSYNC_AUTO_SERVER:
++                    {
++                        struct event *event = obj->shm;
++
++                        for (spin = 0; spin <= spincount; ++spin)
++                        {
++                            if (__sync_val_compare_and_swap( &event->signaled, 1, 0 ))
++                            {
++                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                                return i;
++                            }
++                            small_pause();
++                        }
++
++                        futexes[i].addr = &event->signaled;
++                        futexes[i].val = 0;
++                        break;
++                    }
++                    case FSYNC_MANUAL_EVENT:
++                    case FSYNC_MANUAL_SERVER:
++                    case FSYNC_QUEUE:
++                    {
++                        struct event *event = obj->shm;
++
++                        for (spin = 0; spin <= spincount; ++spin)
++                        {
++                            if (__atomic_load_n( &event->signaled, __ATOMIC_SEQ_CST ))
++                            {
++                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                                return i;
++                            }
++                            small_pause();
++                        }
++
++                        futexes[i].addr = &event->signaled;
++                        futexes[i].val = 0;
++                        break;
++                    }
++                    default:
++                        ERR("Invalid type %#x for handle %p.\n", obj->type, handles[i]);
++                        assert(0);
++                    }
++                }
++                else
++                {
++                    /* Avoid breaking things entirely. */
++                    futexes[i].addr = &dummy_futex;
++                    futexes[i].val = dummy_futex;
++                }
++
++#if __SIZEOF_POINTER__ == 4
++                futexes[i].pad = 0;
++#endif
++                futexes[i].bitset = ~0;
++            }
++
++            if (alertable)
++            {
++                /* We already checked if it was signaled; don't bother doing it again. */
++                futexes[i].addr = ntdll_get_thread_data()->fsync_apc_futex;
++                futexes[i].val = 0;
++#if __SIZEOF_POINTER__ == 4
++                futexes[i].pad = 0;
++#endif
++                futexes[i].bitset = ~0;
++                i++;
++            }
++            waitcount = i;
++
++            /* Looks like everything is contended, so wait. */
++
++            if (timeout && !timeout->QuadPart)
++            {
++                /* Unlike esync, we already know that we've timed out, so we
++                 * can avoid a syscall. */
++                TRACE("Wait timed out.\n");
++                return STATUS_TIMEOUT;
++            }
++            else if (timeout)
++            {
++                LONGLONG timeleft = update_timeout( end );
++                struct timespec tmo_p;
++                tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
++                tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
++
++                ret = futex_wait_multiple( futexes, waitcount, &tmo_p );
++            }
++            else
++                ret = futex_wait_multiple( futexes, waitcount, NULL );
++
++            /* FUTEX_WAIT_MULTIPLE can succeed or return -EINTR, -EAGAIN,
++             * -EFAULT/-EACCES, -ETIMEDOUT. In the first three cases we need to
++             * try again, bad address is already handled by the fact that we
++             * tried to read from it, so only break out on a timeout. */
++            if (ret == -1 && errno == ETIMEDOUT)
++            {
++                TRACE("Wait timed out.\n");
++                return STATUS_TIMEOUT;
++            }
++        } /* while (1) */
++    }
++    else
++    {
++        /* Wait-all is a little trickier to implement correctly. Fortunately,
++         * it's not as common.
++         *
++         * The idea is basically just to wait in sequence on every object in the
++         * set. Then when we're done, try to grab them all in a tight loop. If
++         * that fails, release any resources we've grabbed (and yes, we can
++         * reliably do this—it's just mutexes and semaphores that we have to
++         * put back, and in both cases we just put back 1), and if any of that
++         * fails we start over.
++         *
++         * What makes this inherently bad is that we might temporarily grab a
++         * resource incorrectly. Hopefully it'll be quick (and hey, it won't
++         * block on wineserver) so nobody will notice. Besides, consider: if
++         * object A becomes signaled but someone grabs it before we can grab it
++         * and everything else, then they could just as well have grabbed it
++         * before it became signaled. Similarly if object A was signaled and we
++         * were blocking on object B, then B becomes available and someone grabs
++         * A before we can, then they might have grabbed A before B became
++         * signaled. In either case anyone who tries to wait on A or B will be
++         * waiting for an instant while we put things back. */
++
++        NTSTATUS status = STATUS_SUCCESS;
++        int current;
++
++        while (1)
++        {
++            BOOL abandoned;
++
++tryagain:
++            abandoned = FALSE;
++
++            /* First step: try to wait on each object in sequence. */
++
++            for (i = 0; i < count; i++)
++            {
++                struct fsync *obj = objs[i];
++
++                if (obj && obj->type == FSYNC_MUTEX)
++                {
++                    struct mutex *mutex = obj->shm;
++
++                    if (mutex->tid == GetCurrentThreadId())
++                        continue;
++
++                    while ((current = __atomic_load_n( &mutex->tid, __ATOMIC_SEQ_CST )))
++                    {
++                        status = do_single_wait( &mutex->tid, current, timeout ? &end : NULL, alertable );
++                        if (status != STATUS_PENDING)
++                            break;
++                    }
++                }
++                else if (obj)
++                {
++                    /* this works for semaphores too */
++                    struct event *event = obj->shm;
++
++                    while (!__atomic_load_n( &event->signaled, __ATOMIC_SEQ_CST ))
++                    {
++                        status = do_single_wait( &event->signaled, 0, timeout ? &end : NULL, alertable );
++                        if (status != STATUS_PENDING)
++                            break;
++                    }
++                }
++
++                if (status == STATUS_TIMEOUT)
++                {
++                    TRACE("Wait timed out.\n");
++                    return status;
++                }
++                else if (status == STATUS_USER_APC)
++                    goto userapc;
++            }
++
++            /* If we got here and we haven't timed out, that means all of the
++             * handles were signaled. Check to make sure they still are. */
++            for (i = 0; i < count; i++)
++            {
++                struct fsync *obj = objs[i];
++
++                if (obj && obj->type == FSYNC_MUTEX)
++                {
++                    struct mutex *mutex = obj->shm;
++                    int tid = __atomic_load_n( &mutex->tid, __ATOMIC_SEQ_CST );
++
++                    if (tid && tid != ~0 && tid != GetCurrentThreadId())
++                        goto tryagain;
++                }
++                else if (obj)
++                {
++                    struct event *event = obj->shm;
++
++                    if (!__atomic_load_n( &event->signaled, __ATOMIC_SEQ_CST ))
++                        goto tryagain;
++                }
++            }
++
++            /* Yep, still signaled. Now quick, grab everything. */
++            for (i = 0; i < count; i++)
++            {
++                struct fsync *obj = objs[i];
++                switch (obj->type)
++                {
++                case FSYNC_MUTEX:
++                {
++                    struct mutex *mutex = obj->shm;
++                    int tid = __atomic_load_n( &mutex->tid, __ATOMIC_SEQ_CST );
++                    if (tid == GetCurrentThreadId())
++                        break;
++                    if (tid && tid != ~0)
++                        goto tooslow;
++                    if (__sync_val_compare_and_swap( &mutex->tid, tid, GetCurrentThreadId() ) != tid)
++                        goto tooslow;
++                    if (tid == ~0)
++                        abandoned = TRUE;
++                    break;
++                }
++                case FSYNC_SEMAPHORE:
++                {
++                    struct semaphore *semaphore = obj->shm;
++                    if (__sync_fetch_and_sub( &semaphore->count, 1 ) <= 0)
++                        goto tooslow;
++                    break;
++                }
++                case FSYNC_AUTO_EVENT:
++                case FSYNC_AUTO_SERVER:
++                {
++                    struct event *event = obj->shm;
++                    if (!__sync_val_compare_and_swap( &event->signaled, 1, 0 ))
++                        goto tooslow;
++                    break;
++                }
++                default:
++                    /* If a manual-reset event changed between there and
++                     * here, it's shouldn't be a problem. */
++                    break;
++                }
++            }
++
++            /* If we got here, we successfully waited on every object.
++             * Make sure to let ourselves know that we grabbed the mutexes. */
++            for (i = 0; i < count; i++)
++            {
++                if (objs[i] && objs[i]->type == FSYNC_MUTEX)
++                {
++                    struct mutex *mutex = objs[i]->shm;
++                    mutex->count++;
++                }
++            }
++
++            if (abandoned)
++            {
++                TRACE("Wait successful, but some object(s) were abandoned.\n");
++                return STATUS_ABANDONED;
++            }
++            TRACE("Wait successful.\n");
++            return STATUS_SUCCESS;
++
++tooslow:
++            for (--i; i >= 0; i--)
++            {
++                struct fsync *obj = objs[i];
++                switch (obj->type)
++                {
++                case FSYNC_MUTEX:
++                {
++                    struct mutex *mutex = obj->shm;
++                    /* HACK: This won't do the right thing with abandoned
++                     * mutexes, but fixing it is probably more trouble than
++                     * it's worth. */
++                    __atomic_store_n( &mutex->tid, 0, __ATOMIC_SEQ_CST );
++                    break;
++                }
++                case FSYNC_SEMAPHORE:
++                {
++                    struct semaphore *semaphore = obj->shm;
++                    __sync_fetch_and_add( &semaphore->count, 1 );
++                    break;
++                }
++                case FSYNC_AUTO_EVENT:
++                case FSYNC_AUTO_SERVER:
++                {
++                    struct event *event = obj->shm;
++                    __atomic_store_n( &event->signaled, 1, __ATOMIC_SEQ_CST );
++                    break;
++                }
++                default:
++                    /* doesn't need to be put back */
++                    break;
++                }
++            }
++        } /* while (1) */
++    } /* else (wait-all) */
++
++    assert(0);  /* shouldn't reach here... */
++
++userapc:
++    TRACE("Woken up by user APC.\n");
++
++    /* We have to make a server call anyway to get the APC to execute, so just
++     * delegate down to server_wait(). */
++    ret = server_wait( NULL, 0, SELECT_INTERRUPTIBLE | SELECT_ALERTABLE, &zero );
++
++    /* This can happen if we received a system APC, and the APC fd was woken up
++     * before we got SIGUSR1. poll() doesn't return EINTR in that case. The
++     * right thing to do seems to be to return STATUS_USER_APC anyway. */
++    if (ret == STATUS_TIMEOUT) ret = STATUS_USER_APC;
++    return ret;
++}
++
++/* Like esync, we need to let the server know when we are doing a message wait,
++ * and when we are done with one, so that all of the code surrounding hung
++ * queues works, and we also need this for WaitForInputIdle().
++ *
++ * Unlike esync, we can't wait on the queue fd itself locally. Instead we let
++ * the server do that for us, the way it normally does. This could actually
++ * work for esync too, and that might be better. */
++static void server_set_msgwait( int in_msgwait )
++{
++    SERVER_START_REQ( fsync_msgwait )
++    {
++        req->in_msgwait = in_msgwait;
++        wine_server_call( req );
++    }
++    SERVER_END_REQ;
++}
++
++/* This is a very thin wrapper around the proper implementation above. The
++ * purpose is to make sure the server knows when we are doing a message wait.
++ * This is separated into a wrapper function since there are at least a dozen
++ * exit paths from fsync_wait_objects(). */
++NTSTATUS fsync_wait_objects( DWORD count, const HANDLE *handles, BOOLEAN wait_any,
++                             BOOLEAN alertable, const LARGE_INTEGER *timeout )
++{
++    BOOL msgwait = FALSE;
++    struct fsync *obj;
++    NTSTATUS ret;
++
++    if (count && !get_object( handles[count - 1], &obj ) && obj->type == FSYNC_QUEUE)
++    {
++        msgwait = TRUE;
++        server_set_msgwait( 1 );
++    }
++
++    ret = __fsync_wait_objects( count, handles, wait_any, alertable, timeout );
++
++    if (msgwait)
++        server_set_msgwait( 0 );
++
++    return ret;
++}
++
++NTSTATUS fsync_signal_and_wait( HANDLE signal, HANDLE wait, BOOLEAN alertable,
++    const LARGE_INTEGER *timeout )
++{
++    struct fsync *obj;
++    NTSTATUS ret;
++
++    if ((ret = get_object( signal, &obj ))) return ret;
++
++    switch (obj->type)
++    {
++    case FSYNC_SEMAPHORE:
++        ret = fsync_release_semaphore( signal, 1, NULL );
++        break;
++    case FSYNC_AUTO_EVENT:
++    case FSYNC_MANUAL_EVENT:
++        ret = fsync_set_event( signal, NULL );
++        break;
++    case FSYNC_MUTEX:
++        ret = fsync_release_mutex( signal, NULL );
++        break;
++    default:
++        return STATUS_OBJECT_TYPE_MISMATCH;
++    }
++    if (ret) return ret;
++
++    return fsync_wait_objects( 1, &wait, TRUE, alertable, timeout );
++}
+diff --git a/dlls/ntdll/unix/fsync.h b/dlls/ntdll/unix/fsync.h
+new file mode 100644
+index 00000000000..b3604548554
+--- /dev/null
++++ b/dlls/ntdll/unix/fsync.h
+@@ -0,0 +1,49 @@
++/*
++ * futex-based synchronization objects
++ *
++ * Copyright (C) 2018 Zebediah Figura
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
++ */
++
++extern int do_fsync(void) DECLSPEC_HIDDEN;
++extern void fsync_init(void) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_close( HANDLE handle ) DECLSPEC_HIDDEN;
++
++extern NTSTATUS fsync_create_semaphore(HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_open_semaphore( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_query_semaphore( HANDLE handle, void *info, ULONG *ret_len ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_create_event( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr, EVENT_TYPE type, BOOLEAN initial ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_open_event( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_set_event( HANDLE handle, LONG *prev ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_reset_event( HANDLE handle, LONG *prev ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_pulse_event( HANDLE handle, LONG *prev ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_query_event( HANDLE handle, void *info, ULONG *ret_len ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_create_mutex( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr, BOOLEAN initial ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_open_mutex( HANDLE *handle, ACCESS_MASK access,
++    const OBJECT_ATTRIBUTES *attr ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_release_mutex( HANDLE handle, LONG *prev ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_query_mutex( HANDLE handle, void *info, ULONG *ret_len ) DECLSPEC_HIDDEN;
++
++extern NTSTATUS fsync_wait_objects( DWORD count, const HANDLE *handles, BOOLEAN wait_any,
++                                    BOOLEAN alertable, const LARGE_INTEGER *timeout ) DECLSPEC_HIDDEN;
++extern NTSTATUS fsync_signal_and_wait( HANDLE signal, HANDLE wait,
++    BOOLEAN alertable, const LARGE_INTEGER *timeout ) DECLSPEC_HIDDEN;
+diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
+index 19b73256ef2..d0d979248f8 100644
+--- a/dlls/ntdll/unix/loader.c
++++ b/dlls/ntdll/unix/loader.c
+@@ -87,6 +87,7 @@
+ #include "winternl.h"
+ #include "unix_private.h"
+ #include "esync.h"
++#include "fsync.h"
+ #include "wine/list.h"
+ #include "wine/debug.h"
+ 
+@@ -1565,6 +1566,7 @@ static void start_main_thread(void)
+     signal_init_thread( teb );
+     dbg_init();
+     startup_info_size = server_init_process();
++    fsync_init();
+     esync_init();
+     virtual_map_user_shared_data();
+     init_cpu_info();
+diff --git a/dlls/ntdll/unix/server.c b/dlls/ntdll/unix/server.c
+index 34d4c80eee5..c48a6339fee 100644
+--- a/dlls/ntdll/unix/server.c
++++ b/dlls/ntdll/unix/server.c
+@@ -95,6 +95,7 @@
+ #include "wine/debug.h"
+ #include "unix_private.h"
+ #include "esync.h"
++#include "fsync.h"
+ #include "ddk/wdm.h"
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(server);
+@@ -1698,6 +1699,9 @@ NTSTATUS WINAPI NtClose( HANDLE handle )
+     NTSTATUS ret;
+     int fd = remove_fd_from_cache( handle );
+ 
++    if (do_fsync())
++        fsync_close( handle );
++
+     if (do_esync())
+         esync_close( handle );
+ 
+diff --git a/dlls/ntdll/unix/sync.c b/dlls/ntdll/unix/sync.c
+index 051c672bd12..d8a8eb526a1 100644
+--- a/dlls/ntdll/unix/sync.c
++++ b/dlls/ntdll/unix/sync.c
+@@ -73,6 +73,7 @@
+ #include "wine/debug.h"
+ #include "unix_private.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(sync);
+ 
+@@ -262,6 +262,9 @@ NTSTATUS WINAPI NtCreateSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJ
+     if (max <= 0 || initial < 0 || initial > max) return STATUS_INVALID_PARAMETER;
+     if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
+ 
++    if (do_fsync())
++        return fsync_create_semaphore( handle, access, attr, initial, max );
++
+     if (do_esync())
+         return esync_create_semaphore( handle, access, attr, initial, max );
+ 
+@@ -297,6 +297,9 @@ NTSTATUS WINAPI NtOpenSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJEC
+ {
+     NTSTATUS ret;
+ 
++    if (do_fsync())
++        return fsync_open_semaphore( handle, access, attr );
++
+     if (do_esync())
+         return esync_open_semaphore( handle, access, attr );
+ 
+@@ -327,6 +327,9 @@ NTSTATUS WINAPI NtQuerySemaphore( HANDLE handle, SEMAPHORE_INFORMATION_CLASS cla
+ 
+     if (len != sizeof(SEMAPHORE_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
+ 
++    if (do_fsync())
++        return fsync_query_semaphore( handle, info, ret_len );
++
+     if (do_esync())
+         return esync_query_semaphore( handle, info, ret_len );
+ 
+@@ -367,6 +367,9 @@ NTSTATUS WINAPI NtReleaseSemaphore( HANDLE handle, ULONG count, ULONG *previous
+ {
+     NTSTATUS ret;
+ 
++    if (do_fsync())
++        return fsync_release_semaphore( handle, count, previous );
++
+     if (do_esync())
+         return esync_release_semaphore( handle, count, previous );
+ 
+@@ -394,6 +394,9 @@ NTSTATUS WINAPI NtCreateEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_
+     data_size_t len;
+     struct object_attributes *objattr;
+ 
++    if (do_fsync())
++        return fsync_create_event( handle, access, attr, type, state );
++
+     if (do_esync())
+         return esync_create_event( handle, access, attr, type, state );
+ 
+@@ -428,6 +428,9 @@ NTSTATUS WINAPI NtOpenEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
+ 
+     if ((ret = validate_open_object_attributes( attr ))) return ret;
+ 
++    if (do_fsync())
++        return fsync_open_event( handle, access, attr );
++
+     if (do_esync())
+         return esync_open_event( handle, access, attr );
+ 
+@@ -458,6 +458,9 @@ NTSTATUS WINAPI NtSetEvent( HANDLE handle, LONG *prev_state )
+ {
+     NTSTATUS ret;
+ 
++    if (do_fsync())
++        return fsync_set_event( handle, prev_state );
++
+     if (do_esync())
+         return esync_set_event( handle );
+ 
+@@ -480,6 +480,9 @@ NTSTATUS WINAPI NtResetEvent( HANDLE handle, LONG *prev_state )
+ {
+     NTSTATUS ret;
+ 
++    if (do_fsync())
++        return fsync_reset_event( handle, prev_state );
++
+     if (do_esync())
+         return esync_reset_event( handle );
+ 
+@@ -512,6 +512,9 @@ NTSTATUS WINAPI NtPulseEvent( HANDLE handle, LONG *prev_state )
+ {
+     NTSTATUS ret;
+ 
++    if (do_fsync())
++        return fsync_pulse_event( handle, prev_state );
++
+     if (do_esync())
+         return esync_pulse_event( handle );
+ 
+@@ -537,6 +537,9 @@ NTSTATUS WINAPI NtQueryEvent( HANDLE handle, EVENT_INFORMATION_CLASS class,
+ 
+     if (len != sizeof(EVENT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
+ 
++    if (do_fsync())
++        return fsync_query_event( handle, info, ret_len );
++
+     if (do_esync())
+         return esync_query_event( handle, info, ret_len );
+ 
+@@ -578,6 +578,9 @@ NTSTATUS WINAPI NtCreateMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT
+     data_size_t len;
+     struct object_attributes *objattr;
+ 
++    if (do_fsync())
++        return fsync_create_mutex( handle, access, attr, owned );
++
+     if (do_esync())
+         return esync_create_mutex( handle, access, attr, owned );
+ 
+@@ -611,6 +611,9 @@ NTSTATUS WINAPI NtOpenMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT_A
+ 
+     if ((ret = validate_open_object_attributes( attr ))) return ret;
+ 
++    if (do_fsync())
++        return fsync_open_mutex( handle, access, attr );
++
+     if (do_esync())
+         return esync_open_mutex( handle, access, attr );
+ 
+@@ -641,6 +641,9 @@ NTSTATUS WINAPI NtReleaseMutant( HANDLE handle, LONG *prev_count )
+ {
+     NTSTATUS ret;
+ 
++    if (do_fsync())
++        return fsync_release_mutex( handle, prev_count );
++
+     if (do_esync())
+         return esync_release_mutex( handle, prev_count );
+ 
+@@ -665,6 +665,9 @@ NTSTATUS WINAPI NtQueryMutant( HANDLE handle, MUTANT_INFORMATION_CLASS class,
+ 
+     if (len != sizeof(MUTANT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
+ 
++    if (do_fsync())
++        return fsync_query_mutex( handle, info, ret_len );
++
+     if (do_esync())
+         return esync_query_mutex( handle, info, ret_len );
+ 
+@@ -1286,6 +1286,13 @@ NTSTATUS WINAPI NtWaitForMultipleObjects( DWORD count, const HANDLE *handles, BO
+ 
+     if (!count || count > MAXIMUM_WAIT_OBJECTS) return STATUS_INVALID_PARAMETER_1;
+ 
++    if (do_fsync())
++    {
++        NTSTATUS ret = fsync_wait_objects( count, handles, wait_any, alertable, timeout );
++        if (ret != STATUS_NOT_IMPLEMENTED)
++            return ret;
++    }
++
+     if (do_esync())
+     {
+         NTSTATUS ret = esync_wait_objects( count, handles, wait_any, alertable, timeout );
+@@ -1323,6 +1323,9 @@ NTSTATUS WINAPI NtSignalAndWaitForSingleObject( HANDLE signal, HANDLE wait,
+     select_op_t select_op;
+     UINT flags = SELECT_INTERRUPTIBLE;
+ 
++    if (do_fsync())
++        return fsync_signal_and_wait( signal, wait, alertable, timeout );
++
+     if (do_esync())
+         return esync_signal_and_wait( signal, wait, alertable, timeout );
+ 
+@@ -1348,7 +1348,24 @@ NTSTATUS WINAPI NtYieldExecution(void)
+ NTSTATUS WINAPI NtDelayExecution( BOOLEAN alertable, const LARGE_INTEGER *timeout )
+ {
+     /* if alertable, we need to query the server */
+-    if (alertable) return server_wait( NULL, 0, SELECT_INTERRUPTIBLE | SELECT_ALERTABLE, timeout );
++    if (alertable)
++    {
++        if (do_fsync())
++        {
++            NTSTATUS ret = fsync_wait_objects( 0, NULL, TRUE, TRUE, timeout );
++            if (ret != STATUS_NOT_IMPLEMENTED)
++                return ret;
++        }
++
++        if (do_esync())
++        {
++            NTSTATUS ret = esync_wait_objects( 0, NULL, TRUE, TRUE, timeout );
++            if (ret != STATUS_NOT_IMPLEMENTED)
++                return ret;
++        }
++
++        return server_wait( NULL, 0, SELECT_INTERRUPTIBLE | SELECT_ALERTABLE, timeout );
++    }
+ 
+     if (!timeout || timeout->QuadPart == TIMEOUT_INFINITE)  /* sleep forever */
+     {
+diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
+index e7033932bcb..a2f485d892f 100644
+--- a/dlls/ntdll/unix/unix_private.h
++++ b/dlls/ntdll/unix/unix_private.h
+@@ -59,6 +59,7 @@ struct ntdll_thread_data
+     struct debug_info *debug_info;    /* info for debugstr functions */
+     void              *start_stack;   /* stack for thread startup */
+     int                esync_apc_fd;  /* fd to wait on for user APCs */
++    int               *fsync_apc_futex;
+     int                request_fd;    /* fd for sending server requests */
+     int                reply_fd;      /* fd for receiving server replies */
+     int                wait_fd[2];    /* fd for sleeping server requests */
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index bd89649e769..608c83b579c 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -2683,6 +2683,7 @@ static void init_teb( TEB *teb, PEB *peb )
+     teb->StaticUnicodeString.Buffer = teb->StaticUnicodeBuffer;
+     teb->StaticUnicodeString.MaximumLength = sizeof(teb->StaticUnicodeBuffer);
+     thread_data->esync_apc_fd = -1;
++    thread_data->fsync_apc_futex = NULL;
+     thread_data->request_fd = -1;
+     thread_data->reply_fd   = -1;
+     thread_data->wait_fd[0] = -1;
+diff --git a/server/Makefile.in b/server/Makefile.in
+index 8bd612b4728..6dc5c465e52 100644
+--- a/server/Makefile.in
++++ b/server/Makefile.in
+@@ -15,6 +15,7 @@ C_SRCS = \
+ 	event.c \
+ 	fd.c \
+ 	file.c \
++	fsync.c \
+ 	handle.c \
+ 	hook.c \
+ 	mach.c \
+diff --git a/server/async.c b/server/async.c
+index 1b4f86a1b8b..ceff9c75c27 100644
+--- a/server/async.c
++++ b/server/async.c
+@@ -71,6 +71,7 @@ static const struct object_ops async_ops =
+     remove_queue,              /* remove_queue */
+     async_signaled,            /* signaled */
+     NULL,                      /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     async_satisfied,           /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+@@ -486,6 +487,7 @@ static const struct object_ops iosb_ops =
+     NULL,                     /* remove_queue */
+     NULL,                     /* signaled */
+     NULL,                     /* get_esync_fd */
++    NULL,                     /* get_fsync_idx */
+     NULL,                     /* satisfied */
+     no_signal,                /* signal */
+     no_get_fd,                /* get_fd */
+diff --git a/server/atom.c b/server/atom.c
+index 73d858fef82..7acef97c30d 100644
+--- a/server/atom.c
++++ b/server/atom.c
+@@ -81,6 +81,7 @@ static const struct object_ops atom_table_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+diff --git a/server/change.c b/server/change.c
+index 85afb0cbdc5..7eea72757c5 100644
+--- a/server/change.c
++++ b/server/change.c
+@@ -116,6 +116,7 @@ static const struct object_ops dir_ops =
+     remove_queue,             /* remove_queue */
+     default_fd_signaled,      /* signaled */
+     default_fd_get_esync_fd,  /* get_esync_fd */
++    default_fd_get_fsync_idx, /* get_fsync_idx */
+     no_satisfied,             /* satisfied */
+     no_signal,                /* signal */
+     dir_get_fd,               /* get_fd */
+diff --git a/server/clipboard.c b/server/clipboard.c
+index 54a5fb683cc..1fa61b67a88 100644
+--- a/server/clipboard.c
++++ b/server/clipboard.c
+@@ -78,6 +78,7 @@ static const struct object_ops clipboard_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+diff --git a/server/completion.c b/server/completion.c
+index ef66260c991..2149d0bbf32 100644
+--- a/server/completion.c
++++ b/server/completion.c
+@@ -65,6 +65,7 @@ static const struct object_ops completion_ops =
+     remove_queue,              /* remove_queue */
+     completion_signaled,       /* signaled */
+     NULL,                      /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     no_satisfied,              /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+diff --git a/server/console.c b/server/console.c
+index 78635f3fae1..824b930bba0 100644
+--- a/server/console.c
++++ b/server/console.c
+@@ -43,6 +43,7 @@
+ #include "winternl.h"
+ #include "wine/condrv.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ struct screen_buffer;
+ 
+@@ -82,6 +83,7 @@ static const struct object_ops console_input_ops =
+     remove_queue,                     /* remove_queue */
+     console_input_signaled,           /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     console_input_get_fd,             /* get_fd */
+@@ -136,6 +138,7 @@ struct console_server
+     int                   term_fd;     /* UNIX terminal fd */
+     struct termios        termios;     /* original termios */
+     int                   esync_fd;
++    unsigned int          fsync_idx;
+ };
+ 
+ static void console_server_dump( struct object *obj, int verbose );
+@@ -146,6 +149,7 @@ static struct object *console_server_lookup_name( struct object *obj, struct uni
+ static void console_server_destroy( struct object *obj );
+ static int console_server_signaled( struct object *obj, struct wait_queue_entry *entry );
+ static int console_server_get_esync_fd( struct object *obj, enum esync_type *type );
++static unsigned int console_server_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ static struct fd *console_server_get_fd( struct object *obj );
+ static struct object *console_server_lookup_name( struct object *obj, struct unicode_str *name, unsigned int attr );
+ static struct object *console_server_open_file( struct object *obj, unsigned int access,
+@@ -156,6 +160,7 @@ static const struct object_ops console_server_ops =
+     remove_queue,                     /* remove_queue */
+     console_server_signaled,          /* signaled */
+     console_server_get_esync_fd,      /* get_esync_fd */
++    console_server_get_fsync_idx,     /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     console_server_get_fd,            /* get_fd */
+@@ -224,6 +229,7 @@ static const struct object_ops screen_buffer_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     NULL,                             /* satisfied */
+     no_signal,                        /* signal */
+     screen_buffer_get_fd,             /* get_fd */
+@@ -272,6 +278,7 @@ static const struct object_ops console_device_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     no_get_fd,                        /* get_fd */
+@@ -297,6 +301,7 @@ static const struct object_ops input_device_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     input_device_get_fd,              /* get_fd */
+@@ -327,6 +332,7 @@ static const struct object_ops output_device_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     output_device_get_fd,             /* get_fd */
+@@ -365,6 +371,7 @@ static const struct object_ops console_connection_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     console_connection_get_fd,        /* get_fd */
+@@ -587,8 +587,13 @@ static void disconnect_console_server( struct console_server *server )
+         list_remove( &call->entry );
+         console_host_ioctl_terminate( call, STATUS_CANCELLED );
+     }
++
++    if (do_fsync())
++        fsync_clear_futex( server->fsync_idx );
++
+     if (do_esync())
+         esync_clear( server->esync_fd );
++
+     while (!list_empty( &server->read_queue ))
+     {
+         struct console_host_ioctl *call = LIST_ENTRY( list_head( &server->read_queue ), struct console_host_ioctl, entry );
+@@ -774,6 +787,13 @@ static int console_server_get_esync_fd( struct object *obj, enum esync_type *typ
+     return server->esync_fd;
+ }
+ 
++static unsigned int console_server_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct console_server *server = (struct console_server*)obj;
++    *type = FSYNC_MANUAL_SERVER;
++    return server->fsync_idx;
++}
++
+ static struct fd *console_server_get_fd( struct object* obj )
+ {
+     struct console_server *server = (struct console_server*)obj;
+@@ -806,6 +828,9 @@ static struct object *create_console_server( void )
+     }
+     allow_fd_caching(server->fd);
+ 
++    if (do_fsync())
++        server->fsync_idx = fsync_alloc_shm( 0, 0 );
++
+     if (do_esync())
+         server->esync_fd = esync_create_fd( 0, 0 );
+ 
+@@ -1545,6 +1560,10 @@ DECL_HANDLER(get_next_console_request)
+         /* set result of previous ioctl */
+         ioctl = LIST_ENTRY( list_head( &server->queue ), struct console_host_ioctl, entry );
+         list_remove( &ioctl->entry );
++
++        if (do_fsync() && list_empty( &server->queue ))
++            fsync_clear_futex( server->fsync_idx );
++
+         if (do_esync() && list_empty( &server->queue ))
+             esync_clear( server->esync_fd );
+     }
+@@ -1645,6 +1664,10 @@ DECL_HANDLER(get_next_console_request)
+     {
+         set_error( STATUS_PENDING );
+     }
++
++    if (do_fsync() && list_empty( &server->queue ))
++        fsync_clear_futex( server->fsync_idx );
++
+     if (do_esync() && list_empty( &server->queue ))
+         esync_clear( server->esync_fd );
+ 
+diff --git a/server/debugger.c b/server/debugger.c
+index c37f97aa0b6..b7d88cfd2f2 100644
+--- a/server/debugger.c
++++ b/server/debugger.c
+@@ -74,6 +74,7 @@ static const struct object_ops debug_event_ops =
+     remove_queue,                  /* remove_queue */
+     debug_event_signaled,          /* signaled */
+     NULL,                          /* get_esync_fd */
++    NULL,                          /* get_fsync_idx */
+     no_satisfied,                  /* satisfied */
+     no_signal,                     /* signal */
+     no_get_fd,                     /* get_fd */
+@@ -103,6 +104,7 @@ static const struct object_ops debug_ctx_ops =
+     remove_queue,                  /* remove_queue */
+     debug_obj_signaled,            /* signaled */
+     NULL,                          /* get_esync_fd */
++    NULL,                          /* get_fsync_idx */
+     no_satisfied,                  /* satisfied */
+     no_signal,                     /* signal */
+     no_get_fd,                     /* get_fd */
+diff --git a/server/device.c b/server/device.c
+index b8ce131c732..c56151c9b18 100644
+--- a/server/device.c
++++ b/server/device.c
+@@ -40,6 +40,7 @@
+ #include "request.h"
+ #include "process.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ /* IRP object */
+ 
+@@ -70,6 +71,7 @@ static const struct object_ops irp_call_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     NULL,                             /* satisfied */
+     no_signal,                        /* signal */
+     no_get_fd,                        /* get_fd */
+@@ -97,11 +99,13 @@ struct device_manager
+     struct irp_call       *current_call;   /* call currently executed on client side */
+     struct wine_rb_tree    kernel_objects; /* map of objects that have client side pointer associated */
+     int                    esync_fd;       /* esync file descriptor */
++    unsigned int           fsync_idx;
+ };
+ 
+ static void device_manager_dump( struct object *obj, int verbose );
+ static int device_manager_signaled( struct object *obj, struct wait_queue_entry *entry );
+ static int device_manager_get_esync_fd( struct object *obj, enum esync_type *type );
++static unsigned int device_manager_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ static void device_manager_destroy( struct object *obj );
+ 
+ static const struct object_ops device_manager_ops =
+@@ -113,6 +117,7 @@ static const struct object_ops device_manager_ops =
+     remove_queue,                     /* remove_queue */
+     device_manager_signaled,          /* signaled */
+     device_manager_get_esync_fd,      /* get_esync_fd */
++    device_manager_get_fsync_idx,     /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     no_get_fd,                        /* get_fd */
+@@ -158,6 +163,7 @@ static const struct object_ops device_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     no_get_fd,                        /* get_fd */
+@@ -210,6 +216,7 @@ static const struct object_ops device_file_ops =
+     remove_queue,                     /* remove_queue */
+     default_fd_signaled,              /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     device_file_get_fd,               /* get_fd */
+@@ -754,6 +761,9 @@ static void delete_file( struct device_file *file )
+     /* terminate all pending requests */
+     LIST_FOR_EACH_ENTRY_SAFE( irp, next, &file->requests, struct irp_call, dev_entry )
+     {
++        if (do_fsync() && file->device->manager && list_empty( &file->device->manager->requests ))
++            fsync_clear( &file->device->manager->obj );
++
+         if (do_esync() && file->device->manager && list_empty( &file->device->manager->requests ))
+             esync_clear( file->device->manager->esync_fd );
+ 
+@@ -799,6 +809,13 @@ static int device_manager_get_esync_fd( struct object *obj, enum esync_type *typ
+     return manager->esync_fd;
+ }
+ 
++static unsigned int device_manager_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct device_manager *manager = (struct device_manager *)obj;
++    *type = FSYNC_MANUAL_SERVER;
++    return manager->fsync_idx;
++}
++
+ static void device_manager_destroy( struct object *obj )
+ {
+     struct device_manager *manager = (struct device_manager *)obj;
+@@ -849,6 +866,9 @@ static struct device_manager *create_device_manager(void)
+         list_init( &manager->requests );
+         wine_rb_init( &manager->kernel_objects, compare_kernel_object );
+ 
++        if (do_fsync())
++            manager->fsync_idx = fsync_alloc_shm( 0, 0 );
++
+         if (do_esync())
+             manager->esync_fd = esync_create_fd( 0, 0 );
+     }
+@@ -1017,6 +1037,9 @@ DECL_HANDLER(get_next_device_request)
+                 if (irp->file) grab_object( irp );
+                 manager->current_call = irp;
+ 
++                if (do_fsync() && list_empty( &manager->requests ))
++                    fsync_clear( &manager->obj );
++
+                 if (do_esync() && list_empty( &manager->requests ))
+                     esync_clear( manager->esync_fd );
+             }
+diff --git a/server/directory.c b/server/directory.c
+index 007ec1002ac..62f2e50916f 100644
+--- a/server/directory.c
++++ b/server/directory.c
+@@ -59,6 +59,7 @@ static const struct object_ops object_type_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+@@ -99,6 +100,7 @@ static const struct object_ops directory_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+diff --git a/server/esync.c b/server/esync.c
+index 5c641fdbe01..6395ba4378c 100644
+--- a/server/esync.c
++++ b/server/esync.c
+@@ -44,6 +44,7 @@
+ #include "request.h"
+ #include "file.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ int do_esync(void)
+ {
+@@ -51,7 +52,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC"));
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
+ 
+     return do_esync_cached;
+ #else
+@@ -130,6 +131,7 @@ const struct object_ops esync_ops =
+     NULL,                      /* remove_queue */
+     NULL,                      /* signaled */
+     esync_get_esync_fd,        /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     NULL,                      /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+diff --git a/server/event.c b/server/event.c
+index 8607b494b6d..28a52e61d00 100644
+--- a/server/event.c
++++ b/server/event.c
+@@ -36,6 +36,7 @@
+ #include "request.h"
+ #include "security.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ static const WCHAR event_name[] = {'E','v','e','n','t'};
+ 
+@@ -44,6 +45,7 @@ struct event
+     int            manual_reset;    /* is it a manual reset event? */
+     int            signaled;        /* event has been signaled */
+     int            esync_fd;        /* esync file descriptor */
++    unsigned int   fsync_idx;
+ };
+ 
+ static void event_dump( struct object *obj, int verbose );
+@@ -51,6 +53,7 @@ static void event_dump( struct object *obj, int verbose );
+ static int event_signaled( struct object *obj, struct wait_queue_entry *entry );
+ static void event_satisfied( struct object *obj, struct wait_queue_entry *entry );
+ static int event_get_esync_fd( struct object *obj, enum esync_type *type );
++static unsigned int event_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ static int event_signal( struct object *obj, unsigned int access);
+ static struct list *event_get_kernel_obj_list( struct object *obj );
+ static void event_destroy( struct object *obj );
+@@ -65,6 +68,7 @@ static const struct object_ops event_ops =
+     remove_queue,              /* remove_queue */
+     event_signaled,            /* signaled */
+     event_get_esync_fd,        /* get_esync_fd */
++    event_get_fsync_idx,       /* get_fsync_idx */
+     event_satisfied,           /* satisfied */
+     event_signal,              /* signal */
+     no_get_fd,                 /* get_fd */
+@@ -101,6 +105,7 @@ static const struct object_ops keyed_event_ops =
+     remove_queue,                /* remove_queue */
+     keyed_event_signaled,        /* signaled */
+     NULL,                        /* get_esync_fd */
++    NULL,                        /* get_fsync_idx */
+     no_satisfied,                /* satisfied */
+     no_signal,                   /* signal */
+     no_get_fd,                   /* get_fd */
+@@ -133,6 +138,9 @@ struct event *create_event( struct object *root, const struct unicode_str *name,
+             event->manual_reset = manual_reset;
+             event->signaled     = initial_state;
+ 
++            if (do_fsync())
++                event->fsync_idx = fsync_alloc_shm( initial_state, 0 );
++
+             if (do_esync())
+                 event->esync_fd = esync_create_fd( initial_state, 0 );
+         }
+@@ -143,6 +151,10 @@ struct event *create_event( struct object *root, const struct unicode_str *name,
+ struct event *get_event_obj( struct process *process, obj_handle_t handle, unsigned int access )
+ {
+     struct object *obj;
++
++    if (do_fsync() && (obj = get_handle_obj( process, handle, access, &fsync_ops)))
++        return (struct event *)obj; /* even though it's not an event */
++
+     if (do_esync() && (obj = get_handle_obj( process, handle, access, &esync_ops)))
+         return (struct event *)obj; /* even though it's not an event */
+ 
+@@ -155,10 +167,19 @@ void pulse_event( struct event *event )
+     /* wake up all waiters if manual reset, a single one otherwise */
+     wake_up( &event->obj, !event->manual_reset );
+     event->signaled = 0;
++
++    if (do_fsync())
++        fsync_clear( &event->obj );
+ }
+ 
+ void set_event( struct event *event )
+ {
++    if (do_fsync() && event->obj.ops == &fsync_ops)
++    {
++        fsync_set_event( (struct fsync *)event );
++        return;
++    }
++
+     if (do_esync() && event->obj.ops == &esync_ops)
+     {
+         esync_set_event( (struct esync *)event );
+@@ -172,6 +193,12 @@ void set_event( struct event *event )
+ 
+ void reset_event( struct event *event )
+ {
++    if (do_fsync() && event->obj.ops == &fsync_ops)
++    {
++        fsync_reset_event( (struct fsync *)event );
++        return;
++    }
++
+     if (do_esync() && event->obj.ops == &esync_ops)
+     {
+         esync_reset_event( (struct esync *)event );
+@@ -179,6 +206,9 @@ void reset_event( struct event *event )
+     }
+     event->signaled = 0;
+ 
++    if (do_fsync())
++        fsync_clear( &event->obj );
++
+     if (do_esync())
+         esync_clear( event->esync_fd );
+ }
+@@ -211,6 +241,13 @@ static int event_get_esync_fd( struct object *obj, enum esync_type *type )
+     return event->esync_fd;
+ }
+ 
++static unsigned int event_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct event *event = (struct event *)obj;
++    *type = FSYNC_MANUAL_SERVER;
++    return event->fsync_idx;
++}
++
+ static void event_satisfied( struct object *obj, struct wait_queue_entry *entry )
+ {
+     struct event *event = (struct event *)obj;
+diff --git a/server/fd.c b/server/fd.c
+index bbc2462163d..c558229c3c8 100644
+--- a/server/fd.c
++++ b/server/fd.c
+@@ -103,6 +103,7 @@
+ #include "process.h"
+ #include "request.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ #include "winternl.h"
+ #include "winioctl.h"
+@@ -205,6 +206,7 @@ struct fd
+     apc_param_t          comp_key;    /* completion key to set in completion events */
+     unsigned int         comp_flags;  /* completion flags */
+     int                  esync_fd;    /* esync file descriptor */
++    unsigned int         fsync_idx;   /* fsync shm index */
+ };
+ 
+ static void fd_dump( struct object *obj, int verbose );
+@@ -219,6 +221,7 @@ static const struct object_ops fd_ops =
+     NULL,                     /* remove_queue */
+     NULL,                     /* signaled */
+     NULL,                     /* get_esync_fd */
++    NULL,                     /* get_fsync_idx */
+     NULL,                     /* satisfied */
+     no_signal,                /* signal */
+     no_get_fd,                /* get_fd */
+@@ -261,6 +264,7 @@ static const struct object_ops device_ops =
+     NULL,                     /* remove_queue */
+     NULL,                     /* signaled */
+     NULL,                     /* get_esync_fd */
++    NULL,                     /* get_fsync_idx */
+     NULL,                     /* satisfied */
+     no_signal,                /* signal */
+     no_get_fd,                /* get_fd */
+@@ -302,6 +306,7 @@ static const struct object_ops inode_ops =
+     NULL,                     /* remove_queue */
+     NULL,                     /* signaled */
+     NULL,                     /* get_esync_fd */
++    NULL,                     /* get_fsync_idx */
+     NULL,                     /* satisfied */
+     no_signal,                /* signal */
+     no_get_fd,                /* get_fd */
+@@ -345,6 +350,7 @@ static const struct object_ops file_lock_ops =
+     remove_queue,               /* remove_queue */
+     file_lock_signaled,         /* signaled */
+     NULL,                       /* get_esync_fd */
++    NULL,                       /* get_fsync_idx */
+     no_satisfied,               /* satisfied */
+     no_signal,                  /* signal */
+     no_get_fd,                  /* get_fd */
+@@ -1714,6 +1720,7 @@ static struct fd *alloc_fd_object(void)
+     fd->completion = NULL;
+     fd->comp_flags = 0;
+     fd->esync_fd   = -1;
++    fd->fsync_idx  = 0;
+     init_async_queue( &fd->read_q );
+     init_async_queue( &fd->write_q );
+     init_async_queue( &fd->wait_q );
+@@ -1723,6 +1730,9 @@ static struct fd *alloc_fd_object(void)
+     if (do_esync())
+         fd->esync_fd = esync_create_fd( 1, 0 );
+ 
++    if (do_fsync())
++        fd->fsync_idx = fsync_alloc_shm( 1, 0 );
++
+     if ((fd->poll_index = add_poll_user( fd )) == -1)
+     {
+         release_object( fd );
+@@ -1756,14 +1766,19 @@ struct fd *alloc_pseudo_fd( const struct fd_ops *fd_user_ops, struct object *use
+     fd->comp_flags = 0;
+     fd->no_fd_status = STATUS_BAD_DEVICE_TYPE;
+     fd->esync_fd   = -1;
++    fd->fsync_idx  = 0;
+     init_async_queue( &fd->read_q );
+     init_async_queue( &fd->write_q );
+     init_async_queue( &fd->wait_q );
+     list_init( &fd->inode_entry );
+     list_init( &fd->locks );
+ 
++    if (do_fsync())
++        fd->fsync_idx = fsync_alloc_shm( 0, 0 );
++
+     if (do_esync())
+         fd->esync_fd = esync_create_fd( 0, 0 );
++
+     return fd;
+ }
+ 
+@@ -2190,6 +2205,9 @@ void set_fd_signaled( struct fd *fd, int signaled )
+     fd->signaled = signaled;
+     if (signaled) wake_up( fd->user, 0 );
+ 
++    if (do_fsync() && !signaled)
++        fsync_clear( fd->user );
++
+     if (do_esync() && !signaled)
+         esync_clear( fd->esync_fd );
+ }
+@@ -2232,6 +2250,15 @@ int default_fd_get_esync_fd( struct object *obj, enum esync_type *type )
+     return ret;
+ }
+ 
++unsigned int default_fd_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct fd *fd = get_obj_fd( obj );
++    unsigned int ret = fd->fsync_idx;
++    *type = FSYNC_MANUAL_SERVER;
++    release_object( fd );
++    return ret;
++}
++
+ int default_fd_get_poll_events( struct fd *fd )
+ {
+     int events = 0;
+diff --git a/server/file.c b/server/file.c
+index 49c4ba32b42..829c8685d63 100644
+--- a/server/file.c
++++ b/server/file.c
+@@ -112,6 +112,7 @@ static const struct object_ops file_ops =
+     remove_queue,                 /* remove_queue */
+     default_fd_signaled,          /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     no_satisfied,                 /* satisfied */
+     no_signal,                    /* signal */
+     file_get_fd,                  /* get_fd */
+diff --git a/server/file.h b/server/file.h
+index cae0ac1e395..ed030af8d8f 100644
+--- a/server/file.h
++++ b/server/file.h
+@@ -103,6 +103,7 @@ extern char *dup_fd_name( struct fd *root, const char *name );
+ 
+ extern int default_fd_signaled( struct object *obj, struct wait_queue_entry *entry );
+ extern int default_fd_get_esync_fd( struct object *obj, enum esync_type *type );
++extern unsigned int default_fd_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ extern int default_fd_get_poll_events( struct fd *fd );
+ extern void default_poll_event( struct fd *fd, int event );
+ extern void fd_queue_async( struct fd *fd, struct async *async, int type );
+diff --git a/server/fsync.c b/server/fsync.c
+new file mode 100644
+index 00000000000..0a88ecdd3f6
+--- /dev/null
++++ b/server/fsync.c
+@@ -0,0 +1,524 @@
++/*
++ * futex-based synchronization objects
++ *
++ * Copyright (C) 2018 Zebediah Figura
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
++ */
++
++#include "config.h"
++
++#include <errno.h>
++#include <fcntl.h>
++#include <limits.h>
++#include <stdio.h>
++#include <stdarg.h>
++#include <sys/mman.h>
++#ifdef HAVE_SYS_STAT_H
++# include <sys/stat.h>
++#endif
++#ifdef HAVE_SYS_SYSCALL_H
++# include <sys/syscall.h>
++#endif
++#include <unistd.h>
++
++#include "ntstatus.h"
++#define WIN32_NO_STATUS
++#include "windef.h"
++#include "winternl.h"
++
++#include "handle.h"
++#include "request.h"
++#include "fsync.h"
++
++#include "pshpack4.h"
++struct futex_wait_block
++{
++    int *addr;
++#if __SIZEOF_POINTER__ == 4
++    int pad;
++#endif
++    int val;
++};
++#include "poppack.h"
++
++static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
++        int count, const struct timespec *timeout )
++{
++    return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
++}
++
++int do_fsync(void)
++{
++#ifdef __linux__
++    static int do_fsync_cached = -1;
++
++    if (do_fsync_cached == -1)
++    {
++        static const struct timespec zero;
++        futex_wait_multiple( NULL, 0, &zero );
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++    }
++
++    return do_fsync_cached;
++#else
++    return 0;
++#endif
++}
++
++static char shm_name[29];
++static int shm_fd;
++static off_t shm_size;
++static void **shm_addrs;
++static int shm_addrs_size;  /* length of the allocated shm_addrs array */
++static long pagesize;
++
++static int is_fsync_initialized;
++
++static void shm_cleanup(void)
++{
++    close( shm_fd );
++    if (shm_unlink( shm_name ) == -1)
++        perror( "shm_unlink" );
++}
++
++void fsync_init(void)
++{
++    struct stat st;
++
++    if (fstat( config_dir_fd, &st ) == -1)
++        fatal_error( "cannot stat config dir\n" );
++
++    if (st.st_ino != (unsigned long)st.st_ino)
++        sprintf( shm_name, "/wine-%lx%08lx-fsync", (unsigned long)((unsigned long long)st.st_ino >> 32), (unsigned long)st.st_ino );
++    else
++        sprintf( shm_name, "/wine-%lx-fsync", (unsigned long)st.st_ino );
++
++    if (!shm_unlink( shm_name ))
++        fprintf( stderr, "fsync: warning: a previous shm file %s was not properly removed\n", shm_name );
++
++    shm_fd = shm_open( shm_name, O_RDWR | O_CREAT | O_EXCL, 0644 );
++    if (shm_fd == -1)
++        perror( "shm_open" );
++
++    pagesize = sysconf( _SC_PAGESIZE );
++
++    shm_addrs = calloc( 128, sizeof(shm_addrs[0]) );
++    shm_addrs_size = 128;
++
++    shm_size = pagesize;
++    if (ftruncate( shm_fd, shm_size ) == -1)
++        perror( "ftruncate" );
++
++    is_fsync_initialized = 1;
++
++    fprintf( stderr, "fsync: up and running.\n" );
++
++    atexit( shm_cleanup );
++}
++
++static struct list mutex_list = LIST_INIT(mutex_list);
++
++struct fsync
++{
++    struct object  obj;
++    unsigned int   shm_idx;
++    enum fsync_type type;
++    struct list     mutex_entry;
++};
++
++static void fsync_dump( struct object *obj, int verbose );
++static unsigned int fsync_get_fsync_idx( struct object *obj, enum fsync_type *type );
++static unsigned int fsync_map_access( struct object *obj, unsigned int access );
++static void fsync_destroy( struct object *obj );
++
++const struct object_ops fsync_ops =
++{
++    sizeof(struct fsync),      /* size */
++    &no_type,                  /* type */
++    fsync_dump,                /* dump */
++    no_add_queue,              /* add_queue */
++    NULL,                      /* remove_queue */
++    NULL,                      /* signaled */
++    NULL,                      /* get_esync_fd */
++    fsync_get_fsync_idx,       /* get_fsync_idx */
++    NULL,                      /* satisfied */
++    no_signal,                 /* signal */
++    no_get_fd,                 /* get_fd */
++    fsync_map_access,          /* map_access */
++    default_get_sd,            /* get_sd */
++    default_set_sd,            /* set_sd */
++    no_get_full_name,          /* get_full_name */
++    no_lookup_name,            /* lookup_name */
++    directory_link_name,       /* link_name */
++    default_unlink_name,       /* unlink_name */
++    no_open_file,              /* open_file */
++    no_kernel_obj_list,        /* get_kernel_obj_list */
++    no_close_handle,           /* close_handle */
++    fsync_destroy              /* destroy */
++};
++
++static void fsync_dump( struct object *obj, int verbose )
++{
++    struct fsync *fsync = (struct fsync *)obj;
++    assert( obj->ops == &fsync_ops );
++    fprintf( stderr, "fsync idx=%d\n", fsync->shm_idx );
++}
++
++static unsigned int fsync_get_fsync_idx( struct object *obj, enum fsync_type *type)
++{
++    struct fsync *fsync = (struct fsync *)obj;
++    *type = fsync->type;
++    return fsync->shm_idx;
++}
++
++static unsigned int fsync_map_access( struct object *obj, unsigned int access )
++{
++    /* Sync objects have the same flags. */
++    if (access & GENERIC_READ)    access |= STANDARD_RIGHTS_READ | EVENT_QUERY_STATE;
++    if (access & GENERIC_WRITE)   access |= STANDARD_RIGHTS_WRITE | EVENT_MODIFY_STATE;
++    if (access & GENERIC_EXECUTE) access |= STANDARD_RIGHTS_EXECUTE | SYNCHRONIZE;
++    if (access & GENERIC_ALL)     access |= STANDARD_RIGHTS_ALL | EVENT_QUERY_STATE | EVENT_MODIFY_STATE;
++    return access & ~(GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE | GENERIC_ALL);
++}
++
++static void fsync_destroy( struct object *obj )
++{
++    struct fsync *fsync = (struct fsync *)obj;
++    if (fsync->type == FSYNC_MUTEX)
++        list_remove( &fsync->mutex_entry );
++}
++
++static void *get_shm( unsigned int idx )
++{
++    int entry  = (idx * 8) / pagesize;
++    int offset = (idx * 8) % pagesize;
++
++    if (entry >= shm_addrs_size)
++    {
++        int new_size = max(shm_addrs_size * 2, entry + 1);
++
++        if (!(shm_addrs = realloc( shm_addrs, new_size * sizeof(shm_addrs[0]) )))
++            fprintf( stderr, "fsync: couldn't expand shm_addrs array to size %d\n", entry + 1 );
++
++        memset( shm_addrs + shm_addrs_size, 0, (new_size - shm_addrs_size) * sizeof(shm_addrs[0]) );
++
++        shm_addrs_size = new_size;
++    }
++
++    if (!shm_addrs[entry])
++    {
++        void *addr = mmap( NULL, pagesize, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, entry * pagesize );
++        if (addr == (void *)-1)
++        {
++            fprintf( stderr, "fsync: failed to map page %d (offset %#lx): ", entry, entry * pagesize );
++            perror( "mmap" );
++        }
++
++        if (debug_level)
++            fprintf( stderr, "fsync: Mapping page %d at %p.\n", entry, addr );
++
++        if (__sync_val_compare_and_swap( &shm_addrs[entry], 0, addr ))
++            munmap( addr, pagesize ); /* someone beat us to it */
++    }
++
++    return (void *)((unsigned long)shm_addrs[entry] + offset);
++}
++
++/* FIXME: This is rather inefficient... */
++static unsigned int shm_idx_counter = 1;
++
++unsigned int fsync_alloc_shm( int low, int high )
++{
++#ifdef __linux__
++    int shm_idx;
++    int *shm;
++
++    /* this is arguably a bit of a hack, but we need some way to prevent
++     * allocating shm for the master socket */
++    if (!is_fsync_initialized)
++        return 0;
++
++    shm_idx = shm_idx_counter++;
++
++    while (shm_idx * 8 >= shm_size)
++    {
++        /* Better expand the shm section. */
++        shm_size += pagesize;
++        if (ftruncate( shm_fd, shm_size ) == -1)
++        {
++            fprintf( stderr, "fsync: couldn't expand %s to size %jd: ",
++                shm_name, shm_size );
++            perror( "ftruncate" );
++        }
++    }
++
++    shm = get_shm( shm_idx );
++    assert(shm);
++    shm[0] = low;
++    shm[1] = high;
++
++    return shm_idx;
++#else
++    return 0;
++#endif
++}
++
++static int type_matches( enum fsync_type type1, enum fsync_type type2 )
++{
++    return (type1 == type2) ||
++           ((type1 == FSYNC_AUTO_EVENT || type1 == FSYNC_MANUAL_EVENT) &&
++            (type2 == FSYNC_AUTO_EVENT || type2 == FSYNC_MANUAL_EVENT));
++}
++
++struct fsync *create_fsync( struct object *root, const struct unicode_str *name,
++    unsigned int attr, int low, int high, enum fsync_type type,
++    const struct security_descriptor *sd )
++{
++#ifdef __linux__
++    struct fsync *fsync;
++
++    if ((fsync = create_named_object( root, &fsync_ops, name, attr, sd )))
++    {
++        if (get_error() != STATUS_OBJECT_NAME_EXISTS)
++        {
++            /* initialize it if it didn't already exist */
++
++            /* Initialize the shared memory portion. We want to do this on the
++             * server side to avoid a potential though unlikely race whereby
++             * the same object is opened and used between the time it's created
++             * and the time its shared memory portion is initialized. */
++
++            fsync->shm_idx = fsync_alloc_shm( low, high );
++            fsync->type = type;
++            if (type == FSYNC_MUTEX)
++                list_add_tail( &mutex_list, &fsync->mutex_entry );
++        }
++        else
++        {
++            /* validate the type */
++            if (!type_matches( type, fsync->type ))
++            {
++                release_object( &fsync->obj );
++                set_error( STATUS_OBJECT_TYPE_MISMATCH );
++                return NULL;
++            }
++        }
++    }
++
++    return fsync;
++#else
++    set_error( STATUS_NOT_IMPLEMENTED );
++    return NULL;
++#endif
++}
++
++static inline int futex_wake( int *addr, int val )
++{
++    return syscall( __NR_futex, addr, 1, val, NULL, 0, 0 );
++}
++
++/* shm layout for events or event-like objects. */
++struct fsync_event
++{
++    int signaled;
++    int unused;
++};
++
++void fsync_wake_futex( unsigned int shm_idx )
++{
++    struct fsync_event *event;
++
++    if (debug_level)
++        fprintf( stderr, "fsync_wake_futex: index %u\n", shm_idx );
++
++    if (!shm_idx)
++        return;
++
++    event = get_shm( shm_idx );
++    if (!__atomic_exchange_n( &event->signaled, 1, __ATOMIC_SEQ_CST ))
++        futex_wake( &event->signaled, INT_MAX );
++}
++
++void fsync_wake_up( struct object *obj )
++{
++    enum fsync_type type;
++
++    if (debug_level)
++        fprintf( stderr, "fsync_wake_up: object %p\n", obj );
++
++    if (obj->ops->get_fsync_idx)
++        fsync_wake_futex( obj->ops->get_fsync_idx( obj, &type ) );
++}
++
++void fsync_clear_futex( unsigned int shm_idx )
++{
++    struct fsync_event *event;
++
++    if (debug_level)
++        fprintf( stderr, "fsync_clear_futex: index %u\n", shm_idx );
++
++    if (!shm_idx)
++        return;
++
++    event = get_shm( shm_idx );
++    __atomic_store_n( &event->signaled, 0, __ATOMIC_SEQ_CST );
++}
++
++void fsync_clear( struct object *obj )
++{
++    enum fsync_type type;
++
++    if (debug_level)
++        fprintf( stderr, "fsync_clear: object %p\n", obj );
++
++    if (obj->ops->get_fsync_idx)
++        fsync_clear_futex( obj->ops->get_fsync_idx( obj, &type ) );
++}
++
++void fsync_set_event( struct fsync *fsync )
++{
++    struct fsync_event *event = get_shm( fsync->shm_idx );
++    assert( fsync->obj.ops == &fsync_ops );
++
++    if (!__atomic_exchange_n( &event->signaled, 1, __ATOMIC_SEQ_CST ))
++        futex_wake( &event->signaled, INT_MAX );
++}
++
++void fsync_reset_event( struct fsync *fsync )
++{
++    struct fsync_event *event = get_shm( fsync->shm_idx );
++    assert( fsync->obj.ops == &fsync_ops );
++
++    __atomic_store_n( &event->signaled, 0, __ATOMIC_SEQ_CST );
++}
++
++struct mutex
++{
++    int tid;
++    int count;  /* recursion count */
++};
++
++void fsync_abandon_mutexes( struct thread *thread )
++{
++    struct fsync *fsync;
++
++    LIST_FOR_EACH_ENTRY( fsync, &mutex_list, struct fsync, mutex_entry )
++    {
++        struct mutex *mutex = get_shm( fsync->shm_idx );
++
++        if (mutex->tid == thread->id)
++        {
++            if (debug_level)
++                fprintf( stderr, "fsync_abandon_mutexes() idx=%d\n", fsync->shm_idx );
++            mutex->tid = ~0;
++            mutex->count = 0;
++            futex_wake( &mutex->tid, INT_MAX );
++        }
++    }
++}
++
++DECL_HANDLER(create_fsync)
++{
++    struct fsync *fsync;
++    struct unicode_str name;
++    struct object *root;
++    const struct security_descriptor *sd;
++    const struct object_attributes *objattr = get_req_object_attributes( &sd, &name, &root );
++
++    if (!do_fsync())
++    {
++        set_error( STATUS_NOT_IMPLEMENTED );
++        return;
++    }
++
++    if (!objattr) return;
++
++    if ((fsync = create_fsync( root, &name, objattr->attributes, req->low,
++                               req->high, req->type, sd )))
++    {
++        if (get_error() == STATUS_OBJECT_NAME_EXISTS)
++            reply->handle = alloc_handle( current->process, fsync, req->access, objattr->attributes );
++        else
++            reply->handle = alloc_handle_no_access_check( current->process, fsync,
++                                                          req->access, objattr->attributes );
++
++        reply->shm_idx = fsync->shm_idx;
++        reply->type = fsync->type;
++        release_object( fsync );
++    }
++
++    if (root) release_object( root );
++}
++
++DECL_HANDLER(open_fsync)
++{
++    struct unicode_str name = get_req_unicode_str();
++
++    reply->handle = open_object( current->process, req->rootdir, req->access,
++                                 &fsync_ops, &name, req->attributes );
++
++    if (reply->handle)
++    {
++        struct fsync *fsync;
++
++        if (!(fsync = (struct fsync *)get_handle_obj( current->process, reply->handle,
++                                                      0, &fsync_ops )))
++            return;
++
++        if (!type_matches( req->type, fsync->type ))
++        {
++            set_error( STATUS_OBJECT_TYPE_MISMATCH );
++            release_object( fsync );
++            return;
++        }
++
++        reply->type = fsync->type;
++        reply->shm_idx = fsync->shm_idx;
++        release_object( fsync );
++    }
++}
++
++/* Retrieve the index of a shm section which will be signaled by the server. */
++DECL_HANDLER(get_fsync_idx)
++{
++    struct object *obj;
++    enum fsync_type type;
++
++    if (!(obj = get_handle_obj( current->process, req->handle, SYNCHRONIZE, NULL )))
++        return;
++
++    if (obj->ops->get_fsync_idx)
++    {
++        reply->shm_idx = obj->ops->get_fsync_idx( obj, &type );
++        reply->type = type;
++    }
++    else
++    {
++        if (debug_level)
++        {
++            fprintf( stderr, "%04x: fsync: can't wait on object: ", current->id );
++            obj->ops->dump( obj, 0 );
++        }
++        set_error( STATUS_NOT_IMPLEMENTED );
++    }
++
++    release_object( obj );
++}
++
++DECL_HANDLER(get_fsync_apc_idx)
++{
++    reply->shm_idx = current->fsync_apc_idx;
++}
+diff --git a/server/fsync.h b/server/fsync.h
+new file mode 100644
+index 00000000000..a91939b7f0a
+--- /dev/null
++++ b/server/fsync.h
+@@ -0,0 +1,34 @@
++/*
++ * futex-based synchronization objects
++ *
++ * Copyright (C) 2018 Zebediah Figura
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
++ */
++
++extern int do_fsync(void);
++extern void fsync_init(void);
++extern unsigned int fsync_alloc_shm( int low, int high );
++extern void fsync_wake_futex( unsigned int shm_idx );
++extern void fsync_clear_futex( unsigned int shm_idx );
++extern void fsync_wake_up( struct object *obj );
++extern void fsync_clear( struct object *obj );
++
++struct fsync;
++
++extern const struct object_ops fsync_ops;
++extern void fsync_set_event( struct fsync *fsync );
++extern void fsync_reset_event( struct fsync *fsync );
++extern void fsync_abandon_mutexes( struct thread *thread );
+diff --git a/server/handle.c b/server/handle.c
+index cb5628b7e06..ff44446acc9 100644
+--- a/server/handle.c
++++ b/server/handle.c
+@@ -124,6 +124,7 @@ static const struct object_ops handle_table_ops =
+     NULL,                            /* remove_queue */
+     NULL,                            /* signaled */
+     NULL,                            /* get_esync_fd */
++    NULL,                            /* get_fsync_idx */
+     NULL,                            /* satisfied */
+     no_signal,                       /* signal */
+     no_get_fd,                       /* get_fd */
+diff --git a/server/hook.c b/server/hook.c
+index 61b5014c442..379f9c074d5 100644
+--- a/server/hook.c
++++ b/server/hook.c
+@@ -82,6 +82,7 @@ static const struct object_ops hook_table_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+diff --git a/server/mailslot.c b/server/mailslot.c
+index 18fef4b0466..b541524c9a4 100644
+--- a/server/mailslot.c
++++ b/server/mailslot.c
+@@ -79,6 +79,7 @@ static const struct object_ops mailslot_ops =
+     remove_queue,              /* remove_queue */
+     default_fd_signaled,       /* signaled */
+     NULL,                      /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     no_satisfied,              /* satisfied */
+     no_signal,                 /* signal */
+     mailslot_get_fd,           /* get_fd */
+@@ -138,6 +139,7 @@ static const struct object_ops mail_writer_ops =
+     NULL,                       /* remove_queue */
+     NULL,                       /* signaled */
+     NULL,                       /* get_esync_fd */
++    NULL,                       /* get_fsync_idx */
+     NULL,                       /* satisfied */
+     no_signal,                  /* signal */
+     mail_writer_get_fd,         /* get_fd */
+@@ -202,6 +204,7 @@ static const struct object_ops mailslot_device_ops =
+     NULL,                           /* remove_queue */
+     NULL,                           /* signaled */
+     NULL,                           /* get_esync_fd */
++    NULL,                           /* get_fsync_idx */
+     no_satisfied,                   /* satisfied */
+     no_signal,                      /* signal */
+     no_get_fd,                      /* get_fd */
+@@ -233,6 +236,7 @@ static const struct object_ops mailslot_device_file_ops =
+     remove_queue,                           /* remove_queue */
+     default_fd_signaled,                    /* signaled */
+     NULL,                                   /* get_esync_fd */
++    NULL,                                   /* get_fsync_idx */
+     no_satisfied,                           /* satisfied */
+     no_signal,                              /* signal */
+     mailslot_device_file_get_fd,            /* get_fd */
+diff --git a/server/main.c b/server/main.c
+index 3e02cbb3832..7a09436b637 100644
+--- a/server/main.c
++++ b/server/main.c
+@@ -37,6 +37,7 @@
+ #include "thread.h"
+ #include "request.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ /* command-line options */
+ int debug_level = 0;
+@@ -141,8 +142,14 @@ int main( int argc, char *argv[] )
+     sock_init();
+     open_master_socket();
+ 
++    if (do_fsync())
++        fsync_init();
++
+     if (do_esync())
+         esync_init();
++
++    if (!do_fsync() && !do_esync())
++        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
+ 
+     if (debug_level) fprintf( stderr, "wineserver: starting (pid=%ld)\n", (long) getpid() );
+     set_current_time();
+diff --git a/server/mapping.c b/server/mapping.c
+index 10def3ca694..d55df5145f7 100644
+--- a/server/mapping.c
++++ b/server/mapping.c
+@@ -69,6 +69,7 @@ static const struct object_ops ranges_ops =
+     NULL,                      /* remove_queue */
+     NULL,                      /* signaled */
+     NULL,                      /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     NULL,                      /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+@@ -106,6 +107,7 @@ static const struct object_ops shared_map_ops =
+     NULL,                      /* remove_queue */
+     NULL,                      /* signaled */
+     NULL,                      /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     NULL,                      /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+@@ -165,6 +167,7 @@ static const struct object_ops mapping_ops =
+     NULL,                        /* remove_queue */
+     NULL,                        /* signaled */
+     NULL,                        /* get_esync_fd */
++    NULL,                        /* get_fsync_idx */
+     NULL,                        /* satisfied */
+     no_signal,                   /* signal */
+     mapping_get_fd,              /* get_fd */
+diff --git a/server/mutex.c b/server/mutex.c
+index 1235ab4731f..ccdc383f0df 100644
+--- a/server/mutex.c
++++ b/server/mutex.c
+@@ -62,6 +62,7 @@ static const struct object_ops mutex_ops =
+     remove_queue,              /* remove_queue */
+     mutex_signaled,            /* signaled */
+     NULL,                      /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     mutex_satisfied,           /* satisfied */
+     mutex_signal,              /* signal */
+     no_get_fd,                 /* get_fd */
+diff --git a/server/named_pipe.c b/server/named_pipe.c
+index e59a5b6c183..d0ea32a24d5 100644
+--- a/server/named_pipe.c
++++ b/server/named_pipe.c
+@@ -119,6 +119,7 @@ static const struct object_ops named_pipe_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+@@ -164,6 +165,7 @@ static const struct object_ops pipe_server_ops =
+     remove_queue,                 /* remove_queue */
+     default_fd_signaled,          /* signaled */
+     default_fd_get_esync_fd,      /* get_esync_fd */
++    default_fd_get_fsync_idx,     /* get_fsync_idx */
+     no_satisfied,                 /* satisfied */
+     no_signal,                    /* signal */
+     pipe_end_get_fd,              /* get_fd */
+@@ -208,6 +210,7 @@ static const struct object_ops pipe_client_ops =
+     remove_queue,                 /* remove_queue */
+     default_fd_signaled,          /* signaled */
+     default_fd_get_esync_fd,      /* get_esync_fd */
++    default_fd_get_fsync_idx,     /* get_fsync_idx */
+     no_satisfied,                 /* satisfied */
+     no_signal,                    /* signal */
+     pipe_end_get_fd,              /* get_fd */
+@@ -256,6 +259,7 @@ static const struct object_ops named_pipe_device_ops =
+     NULL,                             /* remove_queue */
+     NULL,                             /* signaled */
+     NULL,                             /* get_esync_fd */
++    NULL,                             /* get_fsync_idx */
+     no_satisfied,                     /* satisfied */
+     no_signal,                        /* signal */
+     no_get_fd,                        /* get_fd */
+@@ -288,6 +292,7 @@ static const struct object_ops named_pipe_device_file_ops =
+     remove_queue,                            /* remove_queue */
+     default_fd_signaled,                     /* signaled */
+     NULL,                                    /* get_esync_fd */
++    NULL,                                    /* get_fsync_idx */
+     no_satisfied,                            /* satisfied */
+     no_signal,                               /* signal */
+     named_pipe_device_file_get_fd,           /* get_fd */
+diff --git a/server/object.h b/server/object.h
+index 5b6bb9cbfe1..4c92b174ef3 100644
+--- a/server/object.h
++++ b/server/object.h
+@@ -70,6 +70,8 @@ struct object_ops
+     int  (*signaled)(struct object *,struct wait_queue_entry *);
+     /* return the esync fd for this object */
+     int (*get_esync_fd)(struct object *, enum esync_type *type);
++    /* return the fsync shm idx for this object */
++    unsigned int (*get_fsync_idx)(struct object *, enum fsync_type *type);
+     /* wait satisfied */
+     void (*satisfied)(struct object *,struct wait_queue_entry *);
+     /* signal an object */
+diff --git a/server/process.c b/server/process.c
+index df50955f621..c4f51dcad30 100644
+--- a/server/process.c
++++ b/server/process.c
+@@ -50,6 +50,7 @@
+ #include "user.h"
+ #include "security.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ /* process object */
+ 
+@@ -70,6 +71,7 @@ static void process_poll_event( struct fd *fd, int event );
+ static struct list *process_get_kernel_obj_list( struct object *obj );
+ static void process_destroy( struct object *obj );
+ static int process_get_esync_fd( struct object *obj, enum esync_type *type );
++static unsigned int process_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ static void terminate_process( struct process *process, struct thread *skip, int exit_code );
+ 
+ static const struct object_ops process_ops =
+@@ -81,6 +83,7 @@ static const struct object_ops process_ops =
+     remove_queue,                /* remove_queue */
+     process_signaled,            /* signaled */
+     process_get_esync_fd,        /* get_esync_fd */
++    process_get_fsync_idx,       /* get_fsync_idx */
+     no_satisfied,                /* satisfied */
+     no_signal,                   /* signal */
+     no_get_fd,                   /* get_fd */
+@@ -133,6 +136,7 @@ static const struct object_ops startup_info_ops =
+     remove_queue,                  /* remove_queue */
+     startup_info_signaled,         /* signaled */
+     NULL,                          /* get_esync_fd */
++    NULL,                          /* get_fsync_idx */
+     no_satisfied,                  /* satisfied */
+     no_signal,                     /* signal */
+     no_get_fd,                     /* get_fd */
+@@ -180,6 +184,7 @@ static const struct object_ops job_ops =
+     remove_queue,                  /* remove_queue */
+     job_signaled,                  /* signaled */
+     NULL,                          /* get_esync_fd */
++    NULL,                          /* get_fsync_idx */
+     no_satisfied,                  /* satisfied */
+     no_signal,                     /* signal */
+     no_get_fd,                     /* get_fd */
+@@ -547,6 +552,7 @@ struct process *create_process( int fd, struct process *parent, int inherit_all,
+     process->rawinput_mouse  = NULL;
+     process->rawinput_kbd    = NULL;
+     process->esync_fd        = -1;
++    process->fsync_idx       = 0;
+     list_init( &process->kernel_object );
+     list_init( &process->thread_list );
+     list_init( &process->locks );
+@@ -603,6 +609,9 @@ struct process *create_process( int fd, struct process *parent, int inherit_all,
+     if (!token_assign_label( process->token, security_high_label_sid ))
+         goto error;
+ 
++    if (do_fsync())
++        process->fsync_idx = fsync_alloc_shm( 0, 0 );
++
+     if (do_esync())
+         process->esync_fd = esync_create_fd( 0, 0 );
+ 
+@@ -685,6 +694,13 @@ static int process_get_esync_fd( struct object *obj, enum esync_type *type )
+     return process->esync_fd;
+ }
+ 
++static unsigned int process_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct process *process = (struct process *)obj;
++    *type = FSYNC_MANUAL_SERVER;
++    return process->fsync_idx;
++}
++
+ static unsigned int process_map_access( struct object *obj, unsigned int access )
+ {
+     access = default_map_access( obj, access );
+diff --git a/server/process.h b/server/process.h
+index eec69ddbcaf..abb4ed31b48 100644
+--- a/server/process.h
++++ b/server/process.h
+@@ -99,6 +99,7 @@ struct process
+     const struct rawinput_device *rawinput_kbd;   /* rawinput keyboard device, if any */
+     struct list          kernel_object;   /* list of kernel object pointers */
+     int                  esync_fd;        /* esync file descriptor (signaled on exit) */
++    unsigned int         fsync_idx;
+ };
+ 
+ #define CPU_FLAG(cpu) (1 << (cpu))
+diff --git a/server/protocol.def b/server/protocol.def
+index 2a8662354f6..381bd8d8218 100644
+--- a/server/protocol.def
++++ b/server/protocol.def
+@@ -3766,3 +3766,57 @@ enum esync_type
+ /* Retrieve the fd to wait on for user APCs. */
+ @REQ(get_esync_apc_fd)
+ @END
++
++enum fsync_type
++{
++    FSYNC_SEMAPHORE = 1,
++    FSYNC_AUTO_EVENT,
++    FSYNC_MANUAL_EVENT,
++    FSYNC_MUTEX,
++    FSYNC_AUTO_SERVER,
++    FSYNC_MANUAL_SERVER,
++    FSYNC_QUEUE,
++};
++
++/* Create a new futex-based synchronization object */
++@REQ(create_fsync)
++    unsigned int access;        /* wanted access rights */
++    int low;                    /* initial value of low word */
++    int high;                   /* initial value of high word */
++    int type;                   /* type of fsync object */
++    VARARG(objattr,object_attributes); /* object attributes */
++@REPLY
++    obj_handle_t handle;        /* handle to the object */
++    int type;                   /* type of fsync object */
++    unsigned int shm_idx;       /* this object's index into the shm section */
++@END
++
++/* Open an fsync object */
++@REQ(open_fsync)
++    unsigned int access;        /* wanted access rights */
++    unsigned int attributes;    /* object attributes */
++    obj_handle_t rootdir;       /* root directory */
++    int          type;          /* type of fsync object */
++    VARARG(name,unicode_str);   /* object name */
++@REPLY
++    obj_handle_t handle;        /* handle to the event */
++    int          type;          /* type of fsync object */
++    unsigned int shm_idx;       /* this object's index into the shm section */
++@END
++
++/* Retrieve the shm index for an object. */
++@REQ(get_fsync_idx)
++    obj_handle_t handle;        /* handle to the object */
++@REPLY
++    int          type;
++    unsigned int shm_idx;
++@END
++
++@REQ(fsync_msgwait)
++    int          in_msgwait;    /* are we in a message wait? */
++@END
++
++@REQ(get_fsync_apc_idx)
++@REPLY
++    unsigned int shm_idx;
++@END
+diff --git a/server/queue.c b/server/queue.c
+index a78748b96ca..dccf43197cf 100644
+--- a/server/queue.c
++++ b/server/queue.c
+@@ -44,6 +44,7 @@
+ #include "request.h"
+ #include "user.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ #define WM_NCMOUSEFIRST WM_NCMOUSEMOVE
+ #define WM_NCMOUSELAST  (WM_NCMOUSEFIRST+(WM_MOUSELAST-WM_MOUSEFIRST))
+@@ -147,6 +148,8 @@ struct msg_queue
+     unsigned int           ignore_post_msg; /* ignore post messages newer than this unique id */
+     int                    esync_fd;        /* esync file descriptor (signalled on message) */
+     int                    esync_in_msgwait; /* our thread is currently waiting on us */
++    unsigned int           fsync_idx;
++    int                    fsync_in_msgwait; /* our thread is currently waiting on us */
+ };
+ 
+ struct hotkey
+@@ -164,6 +167,7 @@ static int msg_queue_add_queue( struct object *obj, struct wait_queue_entry *ent
+ static void msg_queue_remove_queue( struct object *obj, struct wait_queue_entry *entry );
+ static int msg_queue_signaled( struct object *obj, struct wait_queue_entry *entry );
+ static int msg_queue_get_esync_fd( struct object *obj, enum esync_type *type );
++static unsigned int msg_queue_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *entry );
+ static void msg_queue_destroy( struct object *obj );
+ static void msg_queue_poll_event( struct fd *fd, int event );
+@@ -180,6 +184,7 @@ static const struct object_ops msg_queue_ops =
+     msg_queue_remove_queue,    /* remove_queue */
+     msg_queue_signaled,        /* signaled */
+     msg_queue_get_esync_fd,    /* get_esync_fd */
++    msg_queue_get_fsync_idx,   /* get_fsync_idx */
+     msg_queue_satisfied,       /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+@@ -218,6 +223,7 @@ static const struct object_ops thread_input_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+@@ -321,12 +327,17 @@ static struct msg_queue *create_msg_queue( struct thread *thread, struct thread_
+         queue->ignore_post_msg = 0;
+         queue->esync_fd        = -1;
+         queue->esync_in_msgwait = 0;
++        queue->fsync_idx       = 0;
++        queue->fsync_in_msgwait = 0;
+         list_init( &queue->send_result );
+         list_init( &queue->callback_result );
+         list_init( &queue->pending_timers );
+         list_init( &queue->expired_timers );
+         for (i = 0; i < NB_MSG_KINDS; i++) list_init( &queue->msg_list[i] );
+ 
++        if (do_fsync())
++            queue->fsync_idx = fsync_alloc_shm( 0, 0 );
++ 
+         if (do_esync())
+             queue->esync_fd = esync_create_fd( 0, 0 );
+ 
+@@ -509,6 +520,9 @@ static inline void clear_queue_bits( struct msg_queue *queue, unsigned int bits
+         queue->keystate_lock = 0;
+     }
+ 
++    if (do_fsync() && !is_signaled( queue ))
++        fsync_clear( &queue->obj );
++
+     if (do_esync() && !is_signaled( queue ))
+         esync_clear( queue->esync_fd );
+ }
+@@ -970,6 +984,9 @@ static int is_queue_hung( struct msg_queue *queue )
+             return 0;  /* thread is waiting on queue -> not hung */
+     }
+ 
++    if (do_fsync() && queue->fsync_in_msgwait)
++        return 0;   /* thread is waiting on queue in absentia -> not hung */
++
+     if (do_esync() && queue->esync_in_msgwait)
+         return 0;   /* thread is waiting on queue in absentia -> not hung */
+ 
+@@ -1035,6 +1052,13 @@ static int msg_queue_get_esync_fd( struct object *obj, enum esync_type *type )
+     return queue->esync_fd;
+ }
+ 
++static unsigned int msg_queue_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct msg_queue *queue = (struct msg_queue *)obj;
++    *type = FSYNC_QUEUE;
++    return queue->fsync_idx;
++}
++
+ static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *entry )
+ {
+     struct msg_queue *queue = (struct msg_queue *)obj;
+@@ -2517,6 +2541,9 @@ DECL_HANDLER(get_queue_status)
+         reply->changed_bits = queue->changed_bits;
+         queue->changed_bits &= ~req->clear_bits;
+ 
++        if (do_fsync() && !is_signaled( queue ))
++            fsync_clear( &queue->obj );
++
+         if (do_esync() && !is_signaled( queue ))
+             esync_clear( queue->esync_fd );
+     }
+@@ -3536,3 +3563,18 @@ DECL_HANDLER(esync_msgwait)
+     if (queue->fd)
+         set_fd_events( queue->fd, req->in_msgwait ? POLLIN : 0 );
+ }
++
++DECL_HANDLER(fsync_msgwait)
++{
++    struct msg_queue *queue = get_current_queue();
++
++    if (!queue) return;
++    queue->fsync_in_msgwait = req->in_msgwait;
++
++    if (current->process->idle_event && !(queue->wake_mask & QS_SMRESULT))
++        set_event( current->process->idle_event );
++
++    /* and start/stop waiting on the driver */
++    if (queue->fd)
++        set_fd_events( queue->fd, req->in_msgwait ? POLLIN : 0 );
++}
+diff --git a/server/registry.c b/server/registry.c
+index 996bff5ef6d..50b600b4853 100644
+--- a/server/registry.c
++++ b/server/registry.c
+@@ -168,6 +168,7 @@ static const struct object_ops key_ops =
+     NULL,                    /* remove_queue */
+     NULL,                    /* signaled */
+     NULL,                    /* get_esync_fd */
++    NULL,                    /* get_fsync_idx */
+     NULL,                    /* satisfied */
+     no_signal,               /* signal */
+     no_get_fd,               /* get_fd */
+diff --git a/server/request.c b/server/request.c
+index 20b0ec309f3..9fd08139375 100644
+--- a/server/request.c
++++ b/server/request.c
+@@ -97,6 +97,7 @@ static const struct object_ops master_socket_ops =
+     NULL,                          /* remove_queue */
+     NULL,                          /* signaled */
+     NULL,                          /* get_esync_fd */
++    NULL,                          /* get_fsync_idx */
+     NULL,                          /* satisfied */
+     no_signal,                     /* signal */
+     no_get_fd,                     /* get_fd */
+diff --git a/server/semaphore.c b/server/semaphore.c
+index d7d3a24e48f..604721d0d5f 100644
+--- a/server/semaphore.c
++++ b/server/semaphore.c
+@@ -59,6 +59,7 @@ static const struct object_ops semaphore_ops =
+     remove_queue,                  /* remove_queue */
+     semaphore_signaled,            /* signaled */
+     NULL,                          /* get_esync_fd */
++    NULL,                          /* get_fsync_idx */
+     semaphore_satisfied,           /* satisfied */
+     semaphore_signal,              /* signal */
+     no_get_fd,                     /* get_fd */
+diff --git a/server/serial.c b/server/serial.c
+index a50ace9903f..78d33460892 100644
+--- a/server/serial.c
++++ b/server/serial.c
+@@ -93,6 +93,7 @@ static const struct object_ops serial_ops =
+     remove_queue,                 /* remove_queue */
+     default_fd_signaled,          /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     no_satisfied,                 /* satisfied */
+     no_signal,                    /* signal */
+     serial_get_fd,                /* get_fd */
+diff --git a/server/signal.c b/server/signal.c
+index b6d6dcfc4b6..f5ac61b6975 100644
+--- a/server/signal.c
++++ b/server/signal.c
+@@ -68,6 +68,7 @@ static const struct object_ops handler_ops =
+     NULL,                     /* remove_queue */
+     NULL,                     /* signaled */
+     NULL,                     /* get_esync_fd */
++    NULL,                     /* get_fsync_idx */
+     NULL,                     /* satisfied */
+     no_signal,                /* signal */
+     no_get_fd,                /* get_fd */
+diff --git a/server/sock.c b/server/sock.c
+index c2dfa8fb8ce..080efc98942 100644
+--- a/server/sock.c
++++ b/server/sock.c
+@@ -173,6 +173,7 @@ static const struct object_ops sock_ops =
+     remove_queue,                 /* remove_queue */
+     default_fd_signaled,          /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     no_satisfied,                 /* satisfied */
+     no_signal,                    /* signal */
+     sock_get_fd,                  /* get_fd */
+@@ -1175,6 +1176,7 @@ static const struct object_ops ifchange_ops =
+     NULL,                    /* remove_queue */
+     NULL,                    /* signaled */
+     NULL,                    /* get_esync_fd */
++    NULL,                    /* get_fsync_idx */
+     no_satisfied,            /* satisfied */
+     no_signal,               /* signal */
+     ifchange_get_fd,         /* get_fd */
+@@ -1396,6 +1398,7 @@ static const struct object_ops socket_device_ops =
+     NULL,                       /* remove_queue */
+     NULL,                       /* signaled */
+     NULL,                       /* get_esync_fd */
++    NULL,                       /* get_fsync_idx */
+     no_satisfied,               /* satisfied */
+     no_signal,                  /* signal */
+     no_get_fd,                  /* get_fd */
+diff --git a/server/symlink.c b/server/symlink.c
+index 07f3c924f25..0e3e9ee9864 100644
+--- a/server/symlink.c
++++ b/server/symlink.c
+@@ -61,6 +61,7 @@ static const struct object_ops symlink_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+diff --git a/server/thread.c b/server/thread.c
+index 1a245c58396..1fb3603f2a7 100644
+--- a/server/thread.c
++++ b/server/thread.c
+@@ -52,6 +52,7 @@
+ #include "user.h"
+ #include "security.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ 
+ #ifdef __i386__
+@@ -112,6 +113,7 @@ static const struct object_ops thread_apc_ops =
+     remove_queue,               /* remove_queue */
+     thread_apc_signaled,        /* signaled */
+     NULL,                       /* get_esync_fd */
++    NULL,                       /* get_fsync_idx */
+     no_satisfied,               /* satisfied */
+     no_signal,                  /* signal */
+     no_get_fd,                  /* get_fd */
+@@ -150,6 +152,7 @@ static const struct object_ops context_ops =
+     remove_queue,               /* remove_queue */
+     context_signaled,           /* signaled */
+     NULL,                       /* get_esync_fd */
++    NULL,                       /* get_fsync_idx */
+     no_satisfied,               /* satisfied */
+     no_signal,                  /* signal */
+     no_get_fd,                  /* get_fd */
+@@ -173,6 +176,7 @@  
+ static void dump_thread( struct object *obj, int verbose );
+ static int thread_signaled( struct object *obj, struct wait_queue_entry *entry );
+ static int thread_get_esync_fd( struct object *obj, enum esync_type *type );
++static unsigned int thread_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ static unsigned int thread_map_access( struct object *obj, unsigned int access );
+ static void thread_poll_event( struct fd *fd, int event );
+ static struct list *thread_get_kernel_obj_list( struct object *obj );
+@@ -187,6 +191,7 @@ static const struct object_ops thread_ops =
+     remove_queue,               /* remove_queue */
+     thread_signaled,            /* signaled */
+     thread_get_esync_fd,        /* get_esync_fd */
++    thread_get_fsync_idx,       /* get_fsync_idx */
+     no_satisfied,               /* satisfied */
+     no_signal,                  /* signal */
+     no_get_fd,                  /* get_fd */
+@@ -228,6 +233,7 @@ static inline void init_thread_structure( struct thread *thread )
+     thread->entry_point     = 0;
+     thread->esync_fd        = -1;
+     thread->esync_apc_fd    = -1;
++    thread->fsync_idx       = 0;
+     thread->system_regs     = 0;
+     thread->queue           = NULL;
+     thread->wait            = NULL;
+@@ -364,6 +370,12 @@ struct thread *create_thread( int fd, struct process *process, const struct secu
+         return NULL;
+     }
+ 
++    if (do_fsync())
++    {
++        thread->fsync_idx = fsync_alloc_shm( 0, 0 );
++        thread->fsync_apc_idx = fsync_alloc_shm( 0, 0 );
++    }
++
+     if (do_esync())
+     {
+         thread->esync_fd = esync_create_fd( 0, 0 );
+@@ -484,6 +496,13 @@ static int thread_get_esync_fd( struct object *obj, enum esync_type *type )
+     return thread->esync_fd;
+ }
+ 
++static unsigned int thread_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct thread *thread = (struct thread *)obj;
++    *type = FSYNC_MANUAL_SERVER;
++    return thread->fsync_idx;
++}
++
+ static unsigned int thread_map_access( struct object *obj, unsigned int access )
+ {
+     access = default_map_access( obj, access );
+@@ -533,6 +552,7 @@ static struct thread_apc *create_apc( struct object *owner, const apc_call_t *ca
+         apc->result.type = APC_NONE;
+         if (owner) grab_object( owner );
+     }
++
+     return apc;
+ }
+ 
+@@ -1068,6 +1088,9 @@ void wake_up( struct object *obj, int max )
+     struct list *ptr;
+     int ret;
+ 
++    if (do_fsync())
++        fsync_wake_up( obj );
++
+     if (do_esync())
+         esync_wake_up( obj );
+ 
+@@ -1158,6 +1181,9 @@ static int queue_apc( struct process *process, struct thread *thread, struct thr
+     {
+         wake_thread( thread );
+ 
++        if (do_fsync() && queue == &thread->user_apc)
++            fsync_wake_futex( thread->fsync_apc_idx );
++
+         if (do_esync() && queue == &thread->user_apc)
+             esync_wake_fd( thread->esync_apc_fd );
+     }
+@@ -1208,6 +1234,9 @@ static struct thread_apc *thread_dequeue_apc( struct thread *thread, int system
+         list_remove( ptr );
+     }
+ 
++    if (do_fsync() && list_empty( &thread->system_apc ) && list_empty( &thread->user_apc ))
++        fsync_clear_futex( thread->fsync_apc_idx );
++
+     if (do_esync() && list_empty( &thread->system_apc ) && list_empty( &thread->user_apc ))
+         esync_clear( thread->esync_apc_fd );
+ 
+@@ -1327,6 +1356,8 @@ void kill_thread( struct thread *thread, int violent_death )
+     }
+     kill_console_processes( thread, 0 );
+     abandon_mutexes( thread );
++    if (do_fsync())
++        fsync_abandon_mutexes( thread );
+     if (do_esync())
+         esync_abandon_mutexes( thread );
+     if (violent_death)
+diff --git a/server/thread.h b/server/thread.h
+index 0f6108b684a..53627631343 100644
+--- a/server/thread.h
++++ b/server/thread.h
+@@ -56,6 +56,8 @@ struct thread
+     struct list            mutex_list;    /* list of currently owned mutexes */
+     int                    esync_fd;      /* esync file descriptor (signalled on exit) */
+     int                    esync_apc_fd;  /* esync apc fd (signalled when APCs are present) */
++    unsigned int           fsync_idx;
++    unsigned int           fsync_apc_idx;
+     unsigned int           system_regs;   /* which system regs have been set */
+     struct msg_queue      *queue;         /* message queue */
+     struct thread_wait    *wait;          /* current wait condition if sleeping */
+diff --git a/server/timer.c b/server/timer.c
+index dcbc9e2ece5..9d9d7b8b40c 100644
+--- a/server/timer.c
++++ b/server/timer.c
+@@ -37,6 +37,7 @@
+ #include "handle.h"
+ #include "request.h"
+ #include "esync.h"
++#include "fsync.h"
+ 
+ static const WCHAR timer_name[] = {'T','i','m','e','r'};
+ 
+@@ -50,11 +51,13 @@ struct timer
+     client_ptr_t         callback;  /* callback APC function */
+     client_ptr_t         arg;       /* callback argument */
+     int                  esync_fd;  /* esync file descriptor */
++    unsigned int         fsync_idx; /* fsync shm index */
+ };
+ 
+ static void timer_dump( struct object *obj, int verbose );
+ static int timer_signaled( struct object *obj, struct wait_queue_entry *entry );
+ static int timer_get_esync_fd( struct object *obj, enum esync_type *type );
++static unsigned int timer_get_fsync_idx( struct object *obj, enum fsync_type *type );
+ static void timer_satisfied( struct object *obj, struct wait_queue_entry *entry );
+ static void timer_destroy( struct object *obj );
+ 
+@@ -69,6 +72,7 @@ static const struct object_ops timer_ops =
+     remove_queue,              /* remove_queue */
+     timer_signaled,            /* signaled */
+     timer_get_esync_fd,        /* get_esync_fd */
++    timer_get_fsync_idx,       /* get_fsync_idx */
+     timer_satisfied,           /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+@@ -105,6 +109,9 @@ static struct timer *create_timer( struct object *root, const struct unicode_str
+             timer->thread   = NULL;
+             timer->esync_fd = -1;
+ 
++            if (do_fsync())
++                timer->fsync_idx = fsync_alloc_shm( 0, 0 );
++
+             if (do_esync())
+                 timer->esync_fd = esync_create_fd( 0, 0 );
+         }
+@@ -181,6 +188,9 @@ static int set_timer( struct timer *timer, timeout_t expire, unsigned int period
+         period = 0;  /* period doesn't make any sense for a manual timer */
+         timer->signaled = 0;
+ 
++        if (do_fsync())
++            fsync_clear( &timer->obj );
++
+         if (do_esync())
+             esync_clear( timer->esync_fd );
+     }
+@@ -223,6 +233,13 @@ static int timer_get_esync_fd( struct object *obj, enum esync_type *type )
+     return timer->esync_fd;
+ }
+ 
++static unsigned int timer_get_fsync_idx( struct object *obj, enum fsync_type *type )
++{
++    struct timer *timer = (struct timer *)obj;
++    *type = timer->manual ? FSYNC_MANUAL_SERVER : FSYNC_AUTO_SERVER;
++    return timer->fsync_idx;
++}
++
+ static void timer_satisfied( struct object *obj, struct wait_queue_entry *entry )
+ {
+     struct timer *timer = (struct timer *)obj;
+diff --git a/server/token.c b/server/token.c
+index 0f128728b0f..5a80b6fd50e 100644
+--- a/server/token.c
++++ b/server/token.c
+@@ -148,6 +148,7 @@ static const struct object_ops token_ops =
+     NULL,                      /* remove_queue */
+     NULL,                      /* signaled */
+     NULL,                      /* get_esync_fd */
++    NULL,                      /* get_fsync_idx */
+     NULL,                      /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+diff --git a/server/winstation.c b/server/winstation.c
+index 1a031248a7c..388b116bc67 100644
+--- a/server/winstation.c
++++ b/server/winstation.c
+@@ -65,6 +65,7 @@ static const struct object_ops winstation_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+@@ -91,6 +92,7 @@ static const struct object_ops desktop_ops =
+     NULL,                         /* remove_queue */
+     NULL,                         /* signaled */
+     NULL,                         /* get_esync_fd */
++    NULL,                         /* get_fsync_idx */
+     NULL,                         /* satisfied */
+     no_signal,                    /* signal */
+     no_get_fd,                    /* get_fd */
+diff --git a/server/window.c b/server/window.c
+index 996bff5ef6d..50b600b4853 100644
+--- a/server/window.c
++++ b/server/window.c
+@@ -113,6 +113,7 @@ static const struct object_ops window_ops =
+     NULL,                     /* remove_queue */
+     NULL,                     /* signaled */
+     NULL,                     /* get_esync_fd */
++    NULL,                     /* get_fsync_idx */
+     NULL,                     /* satisfied */
+     no_signal,                /* signal */
+     no_get_fd,                /* get_fd */
+From f072cf6366aa8385efdcb4a7b4c49e122f00b750 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Mon, 14 Feb 2022 12:51:27 -0500
+Subject: [PATCH] fsync: Type-check HANDLE in esync_set_event.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/ntdll/unix/fsync.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index 39d969f061d..d468782667a 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -576,6 +576,9 @@ NTSTATUS fsync_set_event( HANDLE handle, LONG *prev )
+     if ((ret = get_object( handle, &obj ))) return ret;
+     event = obj->shm;
+
++    if (obj->type != FSYNC_MANUAL_EVENT && obj->type != FSYNC_AUTO_EVENT)
++        return STATUS_OBJECT_TYPE_MISMATCH;
++
+     if (!(current = __atomic_exchange_n( &event->signaled, 1, __ATOMIC_SEQ_CST )))
+         futex_wake( &event->signaled, INT_MAX );
+
+From 69afcb164ccf8d3ecd5e94cf79c1e31698e14e5c Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 2 Feb 2022 17:02:44 -0500
+Subject: [PATCH] esync: Type-check HANDLE in esync_set_event.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/ntdll/unix/esync.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/dlls/ntdll/unix/esync.c b/dlls/ntdll/unix/esync.c
+index 55c5695964d..4663374653a 100644
+--- a/dlls/ntdll/unix/esync.c
++++ b/dlls/ntdll/unix/esync.c
+@@ -526,6 +526,9 @@ NTSTATUS esync_set_event( HANDLE handle )
+     if ((ret = get_object( handle, &obj ))) return ret;
+     event = obj->shm;
+
++    if (obj->type != ESYNC_MANUAL_EVENT && obj->type != ESYNC_AUTO_EVENT)
++        return STATUS_OBJECT_TYPE_MISMATCH;
++
+     if (obj->type == ESYNC_MANUAL_EVENT)
+     {
+         /* Acquire the spinlock. */
+diff --git a/server/queue.c b/server/queue.c
+index 012795e410d..ba442324276 100644
+--- a/server/queue.c
++++ b/server/queue.c
+@@ -2536,6 +2536,8 @@ DECL_HANDLER(set_queue_mask)
+             if (req->skip_wait) queue->wake_mask = queue->changed_mask = 0;
+             else wake_up( &queue->obj, 0 );
+         }
++        if (do_fsync() && !is_signaled( queue ))
++            fsync_clear( &queue->obj );
+
+         if (do_esync() && !is_signaled( queue ))
+             esync_clear( queue->esync_fd );
+@@ -2807,6 +2809,9 @@ DECL_HANDLER(get_message)
+     queue->changed_mask = req->changed_mask;
+     set_error( STATUS_PENDING );  /* FIXME */
+
++    if (do_fsync() && !is_signaled( queue ))
++        fsync_clear( &queue->obj );
++
+     if (do_esync() && !is_signaled( queue ))
+         esync_clear( queue->esync_fd );
+
+

--- a/custompatches/0001-02-fsync_futex_waitv.patch
+++ b/custompatches/0001-02-fsync_futex_waitv.patch
@@ -1,0 +1,916 @@
+From 04904bbab87d5662e40743f26534a74ee7d2c943 Mon Sep 17 00:00:00 2001
+From: Tk-Glitch <ti3nou@gmail.com>
+Date: Wed, 16 Mar 2022 11:50:28 +0100
+Subject: Import futex_waitv support from Proton Experimental
+ https://github.com/ValveSoftware/wine/tree/205874085341305cac84ae61a0141d2fa5b892dd
+ From ntdll/fsync: Support futex_waitv() API to ntdll: Include linux/futex.h in fsync.c
+
+
+diff --git a/configure b/configure
+index 7ea8b1c0ceb..03533857085 100755
+--- a/configure
++++ b/configure
+@@ -7982,6 +7982,12 @@ if test "x$ac_cv_header_linux_filter_h" = xyes
+ then :
+   printf "%s\n" "#define HAVE_LINUX_FILTER_H 1" >>confdefs.h
+ 
++fi
++ac_fn_c_check_header_compile "$LINENO" "linux/futex.h" "ac_cv_header_linux_futex_h" "$ac_includes_default"
++if test "x$ac_cv_header_linux_futex_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_LINUX_FUTEX_H 1" >>confdefs.h
++
+ fi
+ ac_fn_c_check_header_compile "$LINENO" "linux/hdreg.h" "ac_cv_header_linux_hdreg_h" "$ac_includes_default"
+ if test "x$ac_cv_header_linux_hdreg_h" = xyes
+diff --git a/configure.ac b/configure.ac
+index 815e40fa08d..0082bd7e4a7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -441,6 +441,7 @@ AC_CHECK_HEADERS(\
+ 	link.h \
+ 	linux/cdrom.h \
+ 	linux/filter.h \
++	linux/futex.h \
+ 	linux/hdreg.h \
+ 	linux/hidraw.h \
+ 	linux/input.h \
+diff --git a/dlls/ntdll/unix/esync.c b/dlls/ntdll/unix/esync.c
+index 3b97bfd62ad..0c6c5b8553b 100644
+--- a/dlls/ntdll/unix/esync.c
++++ b/dlls/ntdll/unix/esync.c
+@@ -953,6 +953,8 @@ static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEA
+ 
+                     if (event->signaled)
+                     {
++                        if (ac_odyssey && alertable)
++                            usleep( 0 );
+                         if ((size = read( obj->fd, &value, sizeof(value) )) == sizeof(value))
+                         {
+                             TRACE("Woken up by handle %p [%d].\n", handles[i], i);
+@@ -968,6 +970,12 @@ static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEA
+ 
+                     if (event->signaled)
+                     {
++                        if (ac_odyssey && alertable)
++                        {
++                            usleep( 0 );
++                            if (!event->signaled)
++                                break;
++                        }
+                         TRACE("Woken up by handle %p [%d].\n", handles[i], i);
+                         return i;
+                     }
+@@ -996,6 +1004,9 @@ static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEA
+ 
+         while (1)
+         {
++            if (ac_odyssey && alertable)
++                usleep( 0 );
++
+             ret = do_poll( fds, pollcount, timeout ? &end : NULL );
+             if (ret > 0)
+             {
+diff --git a/dlls/ntdll/unix/file.c b/dlls/ntdll/unix/file.c
+index d0f8be6c309..f9f6e252b6c 100644
+--- a/dlls/ntdll/unix/file.c
++++ b/dlls/ntdll/unix/file.c
+@@ -5363,6 +5363,230 @@ static NTSTATUS set_pending_write( HANDLE device )
+     return status;
+ }
+ 
++static pthread_mutex_t async_file_read_mutex = PTHREAD_MUTEX_INITIALIZER;
++static pthread_cond_t async_file_read_cond = PTHREAD_COND_INITIALIZER;
++
++struct async_file_read_job
++{
++    HANDLE handle;
++    int unix_handle;
++    int needs_close;
++    HANDLE event;
++    IO_STATUS_BLOCK *io;
++    void *buffer;
++    ULONG length;
++    LARGE_INTEGER offset;
++    DWORD thread_id;
++    LONG  cancelled;
++    struct list queue_entry;
++    struct async_file_read_job *next;
++};
++
++
++static struct list async_file_read_queue = LIST_INIT( async_file_read_queue );
++static struct async_file_read_job *async_file_read_running, *async_file_read_free;
++
++static void async_file_complete_io( struct async_file_read_job *job, NTSTATUS status, ULONG total )
++{
++    job->io->u.Status = status;
++    job->io->Information = total;
++
++    if (job->event) NtSetEvent( job->event, NULL );
++}
++
++static void *async_file_read_thread(void *dummy)
++{
++    struct async_file_read_job *job, *ptr;
++    ULONG buffer_length = 0;
++    void *buffer = NULL;
++    struct list *entry;
++    NTSTATUS status;
++    ULONG total;
++    int result;
++
++    pthread_mutex_lock( &async_file_read_mutex );
++    while (1)
++    {
++        while (!(entry = list_head( &async_file_read_queue )))
++        {
++            pthread_cond_wait( &async_file_read_cond, &async_file_read_mutex );
++            continue;
++        }
++
++        job = LIST_ENTRY( entry, struct async_file_read_job, queue_entry );
++        list_remove( entry );
++
++        total = 0;
++
++        if ( job->cancelled )
++        {
++            pthread_mutex_unlock( &async_file_read_mutex );
++            status = STATUS_CANCELLED;
++            goto done;
++        }
++
++        job->next = async_file_read_running;
++        async_file_read_running = job;
++        pthread_mutex_unlock( &async_file_read_mutex );
++
++        if (!buffer_length)
++        {
++            buffer = malloc(job->length);
++            buffer_length = job->length;
++        }
++        else if (buffer_length < job->length)
++        {
++            buffer = realloc(buffer, job->length);
++            buffer_length = job->length;
++        }
++
++        while ((result = pread( job->unix_handle, buffer, job->length, job->offset.QuadPart )) == -1)
++        {
++            if (errno != EINTR)
++            {
++                status = errno_to_status( errno );
++                goto done;
++            }
++            if (job->cancelled)
++                break;
++        }
++
++        total = result;
++        status = (total || !job->length) ? STATUS_SUCCESS : STATUS_END_OF_FILE;
++done:
++        if (job->needs_close) close( job->unix_handle );
++
++        if (!InterlockedCompareExchange(&job->cancelled, 1, 0))
++        {
++            if (status == STATUS_SUCCESS)
++                memcpy( job->buffer, buffer, total );
++
++            async_file_complete_io( job, status, total );
++        }
++
++        pthread_mutex_lock( &async_file_read_mutex );
++
++        if (status != STATUS_CANCELLED)
++        {
++            ptr = async_file_read_running;
++            if (job == ptr)
++            {
++                async_file_read_running = job->next;
++            }
++            else
++            {
++                while (ptr && ptr->next != job)
++                    ptr = ptr->next;
++
++                assert( ptr );
++                ptr->next = job->next;
++            }
++        }
++
++        job->next = async_file_read_free;
++        async_file_read_free = job;
++    }
++
++    return NULL;
++}
++
++static pthread_once_t async_file_read_once = PTHREAD_ONCE_INIT;
++
++static void async_file_read_init(void)
++{
++    pthread_t async_file_read_thread_id;
++    pthread_attr_t pthread_attr;
++
++    ERR("HACK: AC Odyssey async read workaround.\n");
++
++    pthread_attr_init( &pthread_attr );
++    pthread_attr_setscope( &pthread_attr, PTHREAD_SCOPE_SYSTEM );
++    pthread_attr_setdetachstate( &pthread_attr, PTHREAD_CREATE_DETACHED );
++
++    pthread_create( &async_file_read_thread_id, &pthread_attr, (void * (*)(void *))async_file_read_thread, NULL);
++    pthread_attr_destroy( &pthread_attr );
++}
++
++static NTSTATUS queue_async_file_read( HANDLE handle, int unix_handle, int needs_close, HANDLE event,
++                            IO_STATUS_BLOCK *io, void *buffer, ULONG length, LARGE_INTEGER *offset )
++{
++    struct async_file_read_job *job;
++
++    pthread_once( &async_file_read_once, async_file_read_init );
++
++    NtResetEvent( event, NULL );
++
++    pthread_mutex_lock( &async_file_read_mutex );
++
++    if (async_file_read_free)
++    {
++        job = async_file_read_free;
++        async_file_read_free = async_file_read_free->next;
++    }
++    else
++    {
++        if (!(job = malloc( sizeof(*job) )))
++        {
++            pthread_mutex_unlock( &async_file_read_mutex );
++            return STATUS_NO_MEMORY;
++        }
++    }
++
++    job->handle = handle;
++    job->unix_handle = unix_handle;
++    job->needs_close = needs_close;
++    job->event = event;
++    job->io = io;
++    job->buffer = buffer;
++    job->length = length;
++    job->offset = *offset;
++    job->thread_id = GetCurrentThreadId();
++    job->cancelled = 0;
++
++    list_add_tail( &async_file_read_queue, &job->queue_entry );
++
++    pthread_cond_signal( &async_file_read_cond );
++    pthread_mutex_unlock( &async_file_read_mutex );
++
++    return STATUS_PENDING;
++}
++
++static NTSTATUS cancel_async_file_read( HANDLE handle, IO_STATUS_BLOCK *io )
++{
++    DWORD thread_id = GetCurrentThreadId();
++    struct async_file_read_job *job;
++    unsigned int count = 0;
++
++    TRACE( "handle %p, io %p.\n", handle, io );
++
++    pthread_mutex_lock( &async_file_read_mutex );
++    job = async_file_read_running;
++    while (job)
++    {
++        if (((io && job->io == io)
++                || (!io && job->handle == handle && job->thread_id == thread_id))
++                && !InterlockedCompareExchange(&job->cancelled, 1, 0))
++        {
++            async_file_complete_io( job, STATUS_CANCELLED, 0 );
++            ++count;
++        }
++        job = job->next;
++    }
++
++    LIST_FOR_EACH_ENTRY( job, &async_file_read_queue, struct async_file_read_job, queue_entry )
++    {
++        if (((io && job->io == io)
++                || (!io && job->handle == handle && job->thread_id == thread_id))
++                && !InterlockedCompareExchange(&job->cancelled, 1, 0))
++        {
++            async_file_complete_io( job, STATUS_CANCELLED, 0 );
++            ++count;
++        }
++    }
++
++    pthread_mutex_unlock( &async_file_read_mutex );
++    return count ? STATUS_SUCCESS : STATUS_NOT_FOUND;
++}
+ 
+ /******************************************************************************
+  *              NtReadFile   (NTDLL.@)
+@@ -5404,6 +5628,13 @@ NTSTATUS WINAPI NtReadFile( HANDLE handle, HANDLE event, PIO_APC_ROUTINE apc, vo
+             goto done;
+         }
+ 
++        if (ac_odyssey && async_read && length && event && !apc)
++        {
++            status = queue_async_file_read( handle, unix_handle, needs_close, event, io, buffer, length, offset );
++            needs_close = 0;
++            goto err;
++        }
++
+         if (offset && offset->QuadPart != FILE_USE_FILE_POINTER_POSITION)
+         {
+             /* async I/O doesn't make sense on regular files */
+@@ -6823,6 +7054,9 @@ NTSTATUS WINAPI NtCancelIoFile( HANDLE handle, IO_STATUS_BLOCK *io_status )
+ 
+     TRACE( "%p %p\n", handle, io_status );
+ 
++    if (ac_odyssey && !cancel_async_file_read( handle, NULL ))
++        return (io_status->u.Status = STATUS_SUCCESS);
++
+     SERVER_START_REQ( cancel_async )
+     {
+         req->handle      = wine_server_obj_handle( handle );
+@@ -6848,6 +7082,9 @@ NTSTATUS WINAPI NtCancelIoFileEx( HANDLE handle, IO_STATUS_BLOCK *io, IO_STATUS_
+ 
+     TRACE( "%p %p %p\n", handle, io, io_status );
+ 
++    if (ac_odyssey && !cancel_async_file_read( handle, io ))
++        return (io_status->u.Status = STATUS_SUCCESS);
++
+     SERVER_START_REQ( cancel_async )
+     {
+         req->handle = wine_server_obj_handle( handle );
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index f5ae0a821b0..284e2fcce01 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -27,6 +27,9 @@
+ #include <assert.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#ifdef HAVE_LINUX_FUTEX_H
++# include <linux/futex.h>
++#endif
+ #include <limits.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+@@ -39,6 +42,7 @@
+ # include <sys/syscall.h>
+ #endif
+ #include <unistd.h>
++#include <stdint.h>
+ 
+ #include "ntstatus.h"
+ #define WIN32_NO_STATUS
+@@ -54,43 +58,82 @@
+ WINE_DEFAULT_DEBUG_CHANNEL(fsync);
+ 
+ #include "pshpack4.h"
+-struct futex_wait_block
+-{
+-    int *addr;
+-#if __SIZEOF_POINTER__ == 4
+-    int pad;
++#include "poppack.h"
++
++/* futex_waitv interface */
++
++#ifndef __NR_futex_waitv
++# define __NR_futex_waitv 449
+ #endif
+-    int val;
+-    int bitset;
++
++#ifndef FUTEX_32
++# define FUTEX_32 2
++struct futex_waitv {
++    uint64_t   val;
++    uint64_t   uaddr;
++    uint32_t   flags;
++    uint32_t __reserved;
+ };
+-#include "poppack.h"
++#endif
++
++#define u64_to_ptr(x) (void *)(uintptr_t)(x)
+ 
+-static inline void small_pause(void)
++struct timespec64
+ {
+-#if defined(__i386__) || defined(__x86_64__)
+-    __asm__ __volatile__( "rep;nop" : : : "memory" );
+-#else
+-    __asm__ __volatile__( "" : : : "memory" );
+-#endif
++    long long tv_sec;
++    long long tv_nsec;
++};
++
++static LONGLONG update_timeout( ULONGLONG end )
++{
++    LARGE_INTEGER now;
++    LONGLONG timeleft;
++
++    NtQuerySystemTime( &now );
++    timeleft = end - now.QuadPart;
++    if (timeleft < 0) timeleft = 0;
++    return timeleft;
+ }
+ 
+-static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
+-        int count, const struct timespec *timeout )
++static inline void futex_vector_set( struct futex_waitv *waitv, int *addr, int val )
+ {
+-    return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
++    waitv->uaddr = (uintptr_t) addr;
++    waitv->val = val;
++    waitv->flags = FUTEX_32;
++    waitv->__reserved = 0;
+ }
+ 
+-static inline int futex_wake( int *addr, int val )
++static void simulate_sched_quantum(void)
+ {
+-    return syscall( __NR_futex, addr, 1, val, NULL, 0, 0 );
++    if (!fsync_simulate_sched_quantum) return;
++    /* futex wait is often very quick to resume a waiting thread when woken.
++     * That reveals synchonization bugs in some games which happen to work on
++     * Windows due to the waiting threads having some minimal delay to wake up. */
++    usleep(0);
+ }
+ 
+-static inline int futex_wait( int *addr, int val, struct timespec *timeout )
++static inline int futex_wait_multiple( const struct futex_waitv *futexes,
++        int count, const ULONGLONG *end )
+ {
+-    return syscall( __NR_futex, addr, 0, val, timeout, 0, 0 );
++   if (end)
++   {
++        struct timespec64 timeout;
++        ULONGLONG tmp = *end - SECS_1601_TO_1970 * TICKSPERSEC;
++        timeout.tv_sec = tmp / (ULONGLONG)TICKSPERSEC;
++        timeout.tv_nsec = (tmp % TICKSPERSEC) * 100;
++
++        return syscall( __NR_futex_waitv, futexes, count, 0, &timeout, CLOCK_REALTIME );
++   }
++   else
++   {
++        return syscall( __NR_futex_waitv, futexes, count, 0, NULL, 0 );
++   }
+ }
+ 
+-static unsigned int spincount = 100;
++static inline int futex_wake( int *addr, int val )
++{
++    return syscall( __NR_futex, addr, 1, val, NULL, 0, 0 );
++}
+ 
+ int do_fsync(void)
+ {
+@@ -99,11 +142,16 @@ int do_fsync(void)
+ 
+     if (do_fsync_cached == -1)
+     {
+-        static const struct timespec zero;
+-        futex_wait_multiple( NULL, 0, &zero );
++        FILE *f;
++        if ((f = fopen( "/sys/kernel/futex2/wait", "r" )))
++        {
++            fclose(f);
++            do_fsync_cached = 0;
++            return do_fsync_cached;
++        }
++
++        syscall( __NR_futex_waitv, NULL, 0, 0, NULL, 0 );
+         do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
+-        if (getenv("WINEFSYNC_SPINCOUNT"))
+-            spincount = atoi(getenv("WINEFSYNC_SPINCOUNT"));
+     }
+ 
+     return do_fsync_cached;
+@@ -646,64 +694,30 @@ NTSTATUS fsync_query_mutex( HANDLE handle, void *info, ULONG *ret_len )
+     return STATUS_SUCCESS;
+ }
+ 
+-static LONGLONG update_timeout( ULONGLONG end )
+-{
+-    LARGE_INTEGER now;
+-    LONGLONG timeleft;
+-
+-    NtQuerySystemTime( &now );
+-    timeleft = end - now.QuadPart;
+-    if (timeleft < 0) timeleft = 0;
+-    return timeleft;
+-}
+-
+ static NTSTATUS do_single_wait( int *addr, int val, ULONGLONG *end, BOOLEAN alertable )
+ {
++    struct futex_waitv futexes[2];
+     int ret;
+ 
++    futex_vector_set( &futexes[0], addr, val );
++
+     if (alertable)
+     {
+         int *apc_futex = ntdll_get_thread_data()->fsync_apc_futex;
+-        struct futex_wait_block futexes[2];
+ 
+         if (__atomic_load_n( apc_futex, __ATOMIC_SEQ_CST ))
+             return STATUS_USER_APC;
+ 
+-        futexes[0].addr = addr;
+-        futexes[0].val = val;
+-        futexes[1].addr = apc_futex;
+-        futexes[1].val = 0;
+-#if __SIZEOF_POINTER__ == 4
+-        futexes[0].pad = futexes[1].pad = 0;
+-#endif
+-        futexes[0].bitset = futexes[1].bitset = ~0;
++        futex_vector_set( &futexes[1], apc_futex, 0 );
+ 
+-        if (end)
+-        {
+-            LONGLONG timeleft = update_timeout( *end );
+-            struct timespec tmo_p;
+-            tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
+-            tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
+-            ret = futex_wait_multiple( futexes, 2, &tmo_p );
+-        }
+-        else
+-            ret = futex_wait_multiple( futexes, 2, NULL );
++        ret = futex_wait_multiple( futexes, 2, end );
+ 
+         if (__atomic_load_n( apc_futex, __ATOMIC_SEQ_CST ))
+             return STATUS_USER_APC;
+     }
+     else
+     {
+-        if (end)
+-        {
+-            LONGLONG timeleft = update_timeout( *end );
+-            struct timespec tmo_p;
+-            tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
+-            tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
+-            ret = futex_wait( addr, val, &tmo_p );
+-        }
+-        else
+-            ret = futex_wait( addr, val, NULL );
++        ret = futex_wait_multiple( futexes, 1, end );
+     }
+ 
+     if (!ret)
+@@ -719,12 +733,11 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+ {
+     static const LARGE_INTEGER zero = {0};
+ 
+-    struct futex_wait_block futexes[MAXIMUM_WAIT_OBJECTS + 1];
++    struct futex_waitv futexes[MAXIMUM_WAIT_OBJECTS + 1];
+     struct fsync *objs[MAXIMUM_WAIT_OBJECTS];
++    BOOL msgwait = FALSE, waited = FALSE;
+     int has_fsync = 0, has_server = 0;
+-    BOOL msgwait = FALSE;
+     int dummy_futex = 0;
+-    unsigned int spin;
+     LONGLONG timeleft;
+     LARGE_INTEGER now;
+     DWORD waitcount;
+@@ -834,23 +847,15 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+                         struct semaphore *semaphore = obj->shm;
+                         int current;
+ 
+-                        /* It would be a little clearer (and less error-prone)
+-                         * to use a dedicated interlocked_dec_if_nonzero()
+-                         * helper, but nesting loops like that is probably not
+-                         * great for performance... */
+-                        for (spin = 0; spin <= spincount || current; ++spin)
++                        if ((current = __atomic_load_n( &semaphore->count, __ATOMIC_SEQ_CST ))
++                                && __sync_val_compare_and_swap( &semaphore->count, current, current - 1 ) == current)
+                         {
+-                            if ((current = __atomic_load_n( &semaphore->count, __ATOMIC_SEQ_CST ))
+-                                    && __sync_val_compare_and_swap( &semaphore->count, current, current - 1 ) == current)
+-                            {
+-                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
+-                                return i;
+-                            }
+-                            small_pause();
++                            TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                            if (waited) simulate_sched_quantum();
++                            return i;
+                         }
+ 
+-                        futexes[i].addr = &semaphore->count;
+-                        futexes[i].val = 0;
++                        futex_vector_set( &futexes[i], &semaphore->count, 0 );
+                         break;
+                     }
+                     case FSYNC_MUTEX:
+@@ -862,28 +867,25 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+                         {
+                             TRACE("Woken up by handle %p [%d].\n", handles[i], i);
+                             mutex->count++;
++                            if (waited) simulate_sched_quantum();
+                             return i;
+                         }
+ 
+-                        for (spin = 0; spin <= spincount; ++spin)
++                        if (!(tid = __sync_val_compare_and_swap( &mutex->tid, 0, GetCurrentThreadId() )))
+                         {
+-                            if (!(tid = __sync_val_compare_and_swap( &mutex->tid, 0, GetCurrentThreadId() )))
+-                            {
+-                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
+-                                mutex->count = 1;
+-                                return i;
+-                            }
+-                            else if (tid == ~0 && (tid = __sync_val_compare_and_swap( &mutex->tid, ~0, GetCurrentThreadId() )) == ~0)
+-                            {
+-                                TRACE("Woken up by abandoned mutex %p [%d].\n", handles[i], i);
+-                                mutex->count = 1;
+-                                return STATUS_ABANDONED_WAIT_0 + i;
+-                            }
+-                            small_pause();
++                            TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                            mutex->count = 1;
++                            if (waited) simulate_sched_quantum();
++                            return i;
++                        }
++                        else if (tid == ~0 && (tid = __sync_val_compare_and_swap( &mutex->tid, ~0, GetCurrentThreadId() )) == ~0)
++                        {
++                            TRACE("Woken up by abandoned mutex %p [%d].\n", handles[i], i);
++                            mutex->count = 1;
++                            return STATUS_ABANDONED_WAIT_0 + i;
+                         }
+ 
+-                        futexes[i].addr = &mutex->tid;
+-                        futexes[i].val  = tid;
++                        futex_vector_set( &futexes[i], &mutex->tid, tid );
+                         break;
+                     }
+                     case FSYNC_AUTO_EVENT:
+@@ -891,18 +893,17 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+                     {
+                         struct event *event = obj->shm;
+ 
+-                        for (spin = 0; spin <= spincount; ++spin)
++                        if (__sync_val_compare_and_swap( &event->signaled, 1, 0 ))
+                         {
+-                            if (__sync_val_compare_and_swap( &event->signaled, 1, 0 ))
+-                            {
+-                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
+-                                return i;
+-                            }
+-                            small_pause();
++                            if (ac_odyssey && alertable)
++                                usleep( 0 );
++
++                            TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                            if (waited) simulate_sched_quantum();
++                            return i;
+                         }
+ 
+-                        futexes[i].addr = &event->signaled;
+-                        futexes[i].val = 0;
++                        futex_vector_set( &futexes[i], &event->signaled, 0 );
+                         break;
+                     }
+                     case FSYNC_MANUAL_EVENT:
+@@ -911,18 +912,17 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+                     {
+                         struct event *event = obj->shm;
+ 
+-                        for (spin = 0; spin <= spincount; ++spin)
++                        if (__atomic_load_n( &event->signaled, __ATOMIC_SEQ_CST ))
+                         {
+-                            if (__atomic_load_n( &event->signaled, __ATOMIC_SEQ_CST ))
+-                            {
+-                                TRACE("Woken up by handle %p [%d].\n", handles[i], i);
+-                                return i;
+-                            }
+-                            small_pause();
++                            if (ac_odyssey && alertable)
++                                usleep( 0 );
++
++                            TRACE("Woken up by handle %p [%d].\n", handles[i], i);
++                            if (waited) simulate_sched_quantum();
++                            return i;
+                         }
+ 
+-                        futexes[i].addr = &event->signaled;
+-                        futexes[i].val = 0;
++                        futex_vector_set( &futexes[i], &event->signaled, 0 );
+                         break;
+                     }
+                     default:
+@@ -933,31 +933,22 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+                 else
+                 {
+                     /* Avoid breaking things entirely. */
+-                    futexes[i].addr = &dummy_futex;
+-                    futexes[i].val = dummy_futex;
++                    futex_vector_set( &futexes[i], &dummy_futex, dummy_futex );
+                 }
+-
+-#if __SIZEOF_POINTER__ == 4
+-                futexes[i].pad = 0;
+-#endif
+-                futexes[i].bitset = ~0;
+             }
+ 
+             if (alertable)
+             {
+                 /* We already checked if it was signaled; don't bother doing it again. */
+-                futexes[i].addr = ntdll_get_thread_data()->fsync_apc_futex;
+-                futexes[i].val = 0;
+-#if __SIZEOF_POINTER__ == 4
+-                futexes[i].pad = 0;
+-#endif
+-                futexes[i].bitset = ~0;
+-                i++;
++                futex_vector_set( &futexes[i++], ntdll_get_thread_data()->fsync_apc_futex, 0 );
+             }
+             waitcount = i;
+ 
+             /* Looks like everything is contended, so wait. */
+ 
++            if (ac_odyssey && alertable)
++                usleep( 0 );
++
+             if (timeout && !timeout->QuadPart)
+             {
+                 /* Unlike esync, we already know that we've timed out, so we
+@@ -965,17 +956,8 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+                 TRACE("Wait timed out.\n");
+                 return STATUS_TIMEOUT;
+             }
+-            else if (timeout)
+-            {
+-                LONGLONG timeleft = update_timeout( end );
+-                struct timespec tmo_p;
+-                tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
+-                tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
+ 
+-                ret = futex_wait_multiple( futexes, waitcount, &tmo_p );
+-            }
+-            else
+-                ret = futex_wait_multiple( futexes, waitcount, NULL );
++            ret = futex_wait_multiple( futexes, waitcount, timeout ? &end : NULL );
+ 
+             /* FUTEX_WAIT_MULTIPLE can succeed or return -EINTR, -EAGAIN,
+              * -EFAULT/-EACCES, -ETIMEDOUT. In the first three cases we need to
+@@ -986,6 +968,7 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
+                 TRACE("Wait timed out.\n");
+                 return STATUS_TIMEOUT;
+             }
++            else waited = TRUE;
+         } /* while (1) */
+     }
+     else
+@@ -1090,6 +1073,7 @@ tryagain:
+             for (i = 0; i < count; i++)
+             {
+                 struct fsync *obj = objs[i];
++                if (!obj) continue;
+                 switch (obj->type)
+                 {
+                 case FSYNC_MUTEX:
+@@ -1109,7 +1093,10 @@ tryagain:
+                 case FSYNC_SEMAPHORE:
+                 {
+                     struct semaphore *semaphore = obj->shm;
+-                    if (__sync_fetch_and_sub( &semaphore->count, 1 ) <= 0)
++                    int current;
++
++                    if (!(current = __atomic_load_n( &semaphore->count, __ATOMIC_SEQ_CST ))
++                            || __sync_val_compare_and_swap( &semaphore->count, current, current - 1 ) != current)
+                         goto tooslow;
+                     break;
+                 }
+@@ -1151,6 +1138,7 @@ tooslow:
+             for (--i; i >= 0; i--)
+             {
+                 struct fsync *obj = objs[i];
++                if (!obj) continue;
+                 switch (obj->type)
+                 {
+                 case FSYNC_MUTEX:
+diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
+index 0360bc64b00..f30d900a07b 100644
+--- a/dlls/ntdll/unix/loader.c
++++ b/dlls/ntdll/unix/loader.c
+@@ -2146,6 +2146,33 @@ static struct unix_funcs unix_funcs =
+ #endif
+ };
+ 
++BOOL ac_odyssey;
++BOOL fsync_simulate_sched_quantum;
++
++static void hacks_init(void)
++{
++    static const char upc_exe[] = "Ubisoft Game Launcher\\upc.exe";
++    static const char ac_odyssey_exe[] = "ACOdyssey.exe";
++    const char *env_str;
++
++    if (main_argc > 1 && strstr(main_argv[1], ac_odyssey_exe))
++    {
++        ERR("HACK: AC Odyssey sync tweak on.\n");
++        ac_odyssey = TRUE;
++        return;
++    }
++    env_str = getenv("WINE_FSYNC_SIMULATE_SCHED_QUANTUM");
++    if (env_str)
++        fsync_simulate_sched_quantum = !!atoi(env_str);
++    else if (main_argc > 1)
++        fsync_simulate_sched_quantum = !!strstr(main_argv[1], upc_exe);
++    if (fsync_simulate_sched_quantum)
++        ERR("HACK: Simulating sched quantum in fsync.\n");
++
++    env_str = getenv("SteamGameId");
++    if (env_str && !strcmp(env_str, "50130"))
++        setenv("WINESTEAMNOEXEC", "1", 0);
++}
+ 
+ /***********************************************************************
+  *           start_main_thread
+@@ -2161,6 +2188,7 @@ static void start_main_thread(void)
+     signal_init_thread( teb );
+     dbg_init();
+     startup_info_size = server_init_process();
++    hacks_init();
+     fsync_init();
+     esync_init();
+     virtual_map_user_shared_data();
+diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
+index dbd3e645976..683c2a4f1c2 100644
+--- a/dlls/ntdll/unix/unix_private.h
++++ b/dlls/ntdll/unix/unix_private.h
+@@ -146,6 +146,9 @@ extern BOOL is_wow64 DECLSPEC_HIDDEN;
+ extern struct ldt_copy __wine_ldt_copy DECLSPEC_HIDDEN;
+ #endif
+ 
++extern BOOL ac_odyssey DECLSPEC_HIDDEN;
++extern BOOL fsync_simulate_sched_quantum DECLSPEC_HIDDEN;
++
+ extern void init_environment( int argc, char *argv[], char *envp[] ) DECLSPEC_HIDDEN;
+ extern void init_startup_info(void) DECLSPEC_HIDDEN;
+ extern void *create_startup_info( const UNICODE_STRING *nt_image, const RTL_USER_PROCESS_PARAMETERS *params,
+diff --git a/include/config.h.in b/include/config.h.in
+index 8f9b9737b24..4670e4bc881 100644
+--- a/include/config.h.in
++++ b/include/config.h.in
+@@ -188,6 +188,9 @@
+ /* Define to 1 if you have the <linux/filter.h> header file. */
+ #undef HAVE_LINUX_FILTER_H
+ 
++/* Define to 1 if you have the <linux/futex.h> header file. */
++#undef HAVE_LINUX_FUTEX_H
++
+ /* Define if Linux-style gethostbyname_r and gethostbyaddr_r are available */
+ #undef HAVE_LINUX_GETHOSTBYNAME_R_6
+ 
+diff --git a/server/fsync.c b/server/fsync.c
+index af1c68f2a90..2b8c5e4bc15 100644
+--- a/server/fsync.c
++++ b/server/fsync.c
+@@ -44,21 +44,11 @@
+ #include "fsync.h"
+ 
+ #include "pshpack4.h"
+-struct futex_wait_block
+-{
+-    int *addr;
+-#if __SIZEOF_POINTER__ == 4
+-    int pad;
+-#endif
+-    int val;
+-};
+ #include "poppack.h"
+ 
+-static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
+-        int count, const struct timespec *timeout )
+-{
+-    return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
+-}
++#ifndef __NR_futex_waitv
++#define __NR_futex_waitv 449
++#endif
+ 
+ int do_fsync(void)
+ {
+@@ -67,8 +57,16 @@ int do_fsync(void)
+ 
+     if (do_fsync_cached == -1)
+     {
+-        static const struct timespec zero;
+-        futex_wait_multiple( NULL, 0, &zero );
++        FILE *f;
++        if ((f = fopen( "/sys/kernel/futex2/wait", "r" )))
++        {
++            fclose(f);
++            do_fsync_cached = 0;
++            fprintf( stderr, "fsync: old futex2 patches detected, disabling.\n" );
++            return do_fsync_cached;
++        }
++
++        syscall( __NR_futex_waitv, 0, 0, 0, 0, 0);
+         do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
+     }
+ 

--- a/custompatches/0001-add-wine-unicode-again.patch
+++ b/custompatches/0001-add-wine-unicode-again.patch
@@ -1,0 +1,207 @@
+--- a/include/wine/test.h
++++ b/include/wine/test.h
+@@ -28,6 +28,13 @@
+ #include <winbase.h>
+ #include <wine/debug.h>
+ 
++#ifdef __WINE_CONFIG_H
++#error config.h should not be used in Wine tests
++#endif
++#ifdef __WINE_WINE_UNICODE_H
++#error wine/unicode.h should not be used in Wine tests
++#endif
++
+ #ifndef INVALID_FILE_ATTRIBUTES
+ #define INVALID_FILE_ATTRIBUTES  (~0u)
+ #endif
+--- /dev/null
++++ b/include/wine/unicode.h
+@@ -0,0 +1,178 @@
++/*
++ * Wine internal Unicode definitions
++ *
++ * Copyright 2000 Alexandre Julliard
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
++ */
++
++#if 0
++#pragma makedep install
++#endif
++
++#ifndef __WINE_WINE_UNICODE_H
++#define __WINE_WINE_UNICODE_H
++
++#include <stdarg.h>
++
++#include <windef.h>
++#include <winbase.h>
++#include <winnls.h>
++#include <winternl.h>
++
++#ifdef __WINE_USE_MSVCRT
++#error This file should not be used with msvcrt headers
++#endif
++
++#ifndef WINE_UNICODE_INLINE
++#define WINE_UNICODE_INLINE static FORCEINLINE
++#endif
++
++WINE_UNICODE_INLINE WCHAR tolowerW( WCHAR ch )
++{
++    return RtlDowncaseUnicodeChar( ch );
++}
++
++WINE_UNICODE_INLINE WCHAR toupperW( WCHAR ch )
++{
++    return RtlUpcaseUnicodeChar( ch );
++}
++
++WINE_UNICODE_INLINE int isspaceW( WCHAR wc )
++{
++    unsigned short type;
++    GetStringTypeW( CT_CTYPE1, &wc, 1, &type );
++    return type & C1_SPACE;
++}
++
++WINE_UNICODE_INLINE unsigned int strlenW( const WCHAR *str )
++{
++    const WCHAR *s = str;
++    while (*s) s++;
++    return s - str;
++}
++
++WINE_UNICODE_INLINE WCHAR *strcpyW( WCHAR *dst, const WCHAR *src )
++{
++    WCHAR *p = dst;
++    while ((*p++ = *src++));
++    return dst;
++}
++
++WINE_UNICODE_INLINE WCHAR *strcatW( WCHAR *dst, const WCHAR *src )
++{
++    strcpyW( dst + strlenW(dst), src );
++    return dst;
++}
++
++WINE_UNICODE_INLINE WCHAR *strrchrW( const WCHAR *str, WCHAR ch )
++{
++    WCHAR *ret = NULL;
++    do { if (*str == ch) ret = (WCHAR *)(ULONG_PTR)str; } while (*str++);
++    return ret;
++}
++
++WINE_UNICODE_INLINE int strcmpiW( const WCHAR *str1, const WCHAR *str2 )
++{
++    for (;;)
++    {
++        int ret = tolowerW(*str1) - tolowerW(*str2);
++        if (ret || !*str1) return ret;
++        str1++;
++        str2++;
++    }
++}
++
++WINE_UNICODE_INLINE int strncmpiW( const WCHAR *str1, const WCHAR *str2, int n )
++{
++    int ret = 0;
++    for ( ; n > 0; n--, str1++, str2++)
++        if ((ret = tolowerW(*str1) - tolowerW(*str2)) || !*str1) break;
++    return ret;
++}
++
++WINE_UNICODE_INLINE LONG strtolW( LPCWSTR s, LPWSTR *end, INT base )
++{
++    BOOL negative = FALSE, empty = TRUE;
++    LONG ret = 0;
++
++    if (base < 0 || base == 1 || base > 36) return 0;
++    if (end) *end = (WCHAR *)s;
++    while (isspaceW(*s)) s++;
++
++    if (*s == '-')
++    {
++        negative = TRUE;
++        s++;
++    }
++    else if (*s == '+') s++;
++
++    if ((base == 0 || base == 16) && s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
++    {
++        base = 16;
++        s += 2;
++    }
++    if (base == 0) base = s[0] != '0' ? 10 : 8;
++
++    while (*s)
++    {
++        int v;
++
++        if ('0' <= *s && *s <= '9') v = *s - '0';
++        else if ('A' <= *s && *s <= 'Z') v = *s - 'A' + 10;
++        else if ('a' <= *s && *s <= 'z') v = *s - 'a' + 10;
++        else break;
++        if (v >= base) break;
++        if (negative) v = -v;
++        s++;
++        empty = FALSE;
++
++        if (!negative && (ret > MAXLONG / base || ret * base > MAXLONG - v))
++            ret = MAXLONG;
++        else if (negative && (ret < (LONG)MINLONG / base || ret * base < (LONG)(MINLONG - v)))
++            ret = MINLONG;
++        else
++            ret = ret * base + v;
++    }
++
++    if (end && !empty) *end = (WCHAR *)s;
++    return ret;
++}
++
++NTSYSAPI int __cdecl _vsnwprintf(WCHAR*,size_t,const WCHAR*,__ms_va_list);
++
++static inline int WINAPIV snprintfW( WCHAR *str, size_t len, const WCHAR *format, ...)
++{
++    int retval;
++    __ms_va_list valist;
++    __ms_va_start(valist, format);
++    retval = _vsnwprintf(str, len, format, valist);
++    __ms_va_end(valist);
++    return retval;
++}
++
++static inline int WINAPIV sprintfW( WCHAR *str, const WCHAR *format, ...)
++{
++    int retval;
++    __ms_va_list valist;
++    __ms_va_start(valist, format);
++    retval = _vsnwprintf(str, MAXLONG, format, valist);
++    __ms_va_end(valist);
++    return retval;
++}
++
++#undef WINE_UNICODE_INLINE
++
++#endif  /* __WINE_WINE_UNICODE_H */
+--- a/include/Makefile.in
++++ b/include/Makefile.in
+@@ -850,6 +850,7 @@
+ 	wine/strmbase.h \
+ 	wine/svcctl.idl \
+ 	wine/test.h \
++	wine/unicode.h \
+ 	wine/unixlib.h \
+ 	wine/vulkan.h \
+ 	wine/vulkan_driver.h \

--- a/custompatches/0001-win32u-Factor-out-and-export-__wine_msg_wait_objects.patch
+++ b/custompatches/0001-win32u-Factor-out-and-export-__wine_msg_wait_objects.patch
@@ -1,0 +1,145 @@
+From a26e47f3aa499b01a9cf4e3737df8bfb0a858606 Mon Sep 17 00:00:00 2001
+From: Torge Matthies <openglfreak@googlemail.com>
+Date: Fri, 27 May 2022 00:51:49 +0200
+Subject: [PATCH 1/2] win32u: Factor out and export __wine_msg_wait_objects for
+ high-resolution waits.
+
+---
+ dlls/win32u/message.c | 35 +++++++++++++++++++++++------------
+ include/winuser.h     |  4 +++-
+ 2 files changed, 26 insertions(+), 13 deletions(-)
+
+diff --git a/dlls/win32u/message.c b/dlls/win32u/message.c
+index caffd837c8bd..70413c13bbc6 100644
+--- a/dlls/win32u/message.c
++++ b/dlls/win32u/message.c
+@@ -2104,9 +2104,9 @@ static inline LARGE_INTEGER *get_nt_timeout( LARGE_INTEGER *time, DWORD timeout
+ }
+ 
+ /* wait for message or signaled handle */
+-static DWORD wait_message( DWORD count, const HANDLE *handles, DWORD timeout, DWORD mask, DWORD flags )
++static DWORD wait_message( DWORD count, const HANDLE *handles,
++                           const LARGE_INTEGER *timeout, DWORD mask, DWORD flags )
+ {
+-    LARGE_INTEGER time;
+     DWORD ret, lock;
+     void *ret_ptr;
+     ULONG ret_len;
+@@ -2114,14 +2114,13 @@ static DWORD wait_message( DWORD count, const HANDLE *handles, DWORD timeout, DW
+     if (enable_thunk_lock)
+         lock = KeUserModeCallback( NtUserThunkLock, NULL, 0, &ret_ptr, &ret_len );
+ 
+-    ret = user_driver->pMsgWaitForMultipleObjectsEx( count, handles, get_nt_timeout( &time, timeout ),
+-                                                     mask, flags );
++    ret = user_driver->pMsgWaitForMultipleObjectsEx( count, handles, timeout, mask, flags );
+     if (HIWORD(ret))  /* is it an error code? */
+     {
+         RtlSetLastWin32Error( RtlNtStatusToDosError(ret) );
+         ret = WAIT_FAILED;
+     }
+-    if (ret == WAIT_TIMEOUT && !count && !timeout) NtYieldExecution();
++    if (ret == WAIT_TIMEOUT && !count && !timeout->QuadPart) NtYieldExecution();
+     if ((mask & QS_INPUT) == QS_INPUT) get_user_thread_info()->message_count = 0;
+ 
+     if (enable_thunk_lock)
+@@ -2135,7 +2134,7 @@ static DWORD wait_message( DWORD count, const HANDLE *handles, DWORD timeout, DW
+  *
+  * Wait for multiple objects including the server queue, with specific queue masks.
+  */
+-static DWORD wait_objects( DWORD count, const HANDLE *handles, DWORD timeout,
++static DWORD wait_objects( DWORD count, const HANDLE *handles, const LARGE_INTEGER *timeout,
+                            DWORD wake_mask, DWORD changed_mask, DWORD flags )
+ {
+     struct user_thread_info *thread_info = get_user_thread_info();
+@@ -2178,10 +2177,10 @@ static HANDLE normalize_std_handle( HANDLE handle )
+ }
+ 
+ /***********************************************************************
+- *           NtUserMsgWaitForMultipleObjectsEx   (win32u.@)
++ *           __wine_msg_wait_objects   (win32u.@)
+  */
+-DWORD WINAPI NtUserMsgWaitForMultipleObjectsEx( DWORD count, const HANDLE *handles,
+-                                                DWORD timeout, DWORD mask, DWORD flags )
++DWORD CDECL __wine_msg_wait_objects( DWORD count, const HANDLE *handles,
++                                     const LARGE_INTEGER *timeout, DWORD mask, DWORD flags )
+ {
+     HANDLE wait_handles[MAXIMUM_WAIT_OBJECTS];
+     DWORD i;
+@@ -2200,6 +2199,17 @@ DWORD WINAPI NtUserMsgWaitForMultipleObjectsEx( DWORD count, const HANDLE *handl
+                          (flags & MWMO_INPUTAVAILABLE) ? mask : 0, mask, flags );
+ }
+ 
++/***********************************************************************
++ *           NtUserMsgWaitForMultipleObjectsEx   (win32u.@)
++ */
++DWORD WINAPI NtUserMsgWaitForMultipleObjectsEx( DWORD count, const HANDLE *handles,
++                                                DWORD timeout, DWORD mask, DWORD flags )
++{
++    LARGE_INTEGER time;
++    return __wine_msg_wait_objects( count, handles, get_nt_timeout( &time, timeout ),
++                                    mask, flags );
++}
++
+ /***********************************************************************
+  *           NtUserWaitForInputIdle (win32u.@)
+  */
+@@ -2257,6 +2267,7 @@ DWORD WINAPI NtUserWaitForInputIdle( HANDLE process, DWORD timeout, BOOL wow )
+  */
+ BOOL WINAPI NtUserPeekMessage( MSG *msg_out, HWND hwnd, UINT first, UINT last, UINT flags )
+ {
++    static LARGE_INTEGER zero_timeout;
+     MSG msg;
+     int ret;
+ 
+@@ -2269,7 +2280,7 @@ BOOL WINAPI NtUserPeekMessage( MSG *msg_out, HWND hwnd, UINT first, UINT last, U
+     if (!ret)
+     {
+         flush_window_surfaces( TRUE );
+-        ret = wait_message( 0, NULL, 0, QS_ALLINPUT, 0 );
++        ret = wait_message( 0, NULL, &zero_timeout, QS_ALLINPUT, 0 );
+         /* if we received driver events, check again for a pending message */
+         if (ret == WAIT_TIMEOUT || peek_message( &msg, hwnd, first, last, flags, 0 ) <= 0) return FALSE;
+     }
+@@ -2314,7 +2325,7 @@ BOOL WINAPI NtUserGetMessage( MSG *msg, HWND hwnd, UINT first, UINT last )
+ 
+     while (!(ret = peek_message( msg, hwnd, first, last, PM_REMOVE | (mask << 16), mask )))
+     {
+-        wait_objects( 1, &server_queue, INFINITE, mask & (QS_SENDMESSAGE | QS_SMRESULT), mask, 0 );
++        wait_objects( 1, &server_queue, NULL, mask & (QS_SENDMESSAGE | QS_SMRESULT), mask, 0 );
+     }
+     if (ret < 0) return -1;
+ 
+@@ -2444,7 +2455,7 @@ static void wait_message_reply( UINT flags )
+             continue;
+         }
+ 
+-        wait_message( 1, &server_queue, INFINITE, wake_mask, 0 );
++        wait_message( 1, &server_queue, NULL, wake_mask, 0 );
+     }
+ }
+ 
+diff --git a/include/winuser.h b/include/winuser.h
+index 2f4afffb8a31..606ad36839d8 100644
+--- a/include/winuser.h
++++ b/include/winuser.h
+@@ -2110,7 +2110,7 @@ typedef struct tagMONITORINFO
+ 
+ typedef struct tagMONITORINFOEXA
+ {   /* the 4 first entries are the same as MONITORINFO */
+-    DWORD	cbSize;	
++    DWORD	cbSize;
+     RECT	rcMonitor;
+     RECT	rcWork;
+     DWORD	dwFlags;
+@@ -4764,6 +4764,8 @@ WORD        WINAPI SYSTEM_KillSystemTimer( WORD );
+ 
+ #ifdef __WINESRC__
+ WINUSERAPI BOOL CDECL __wine_send_input( HWND hwnd, const INPUT *input, const RAWINPUT *rawinput );
++WINUSERAPI DWORD CDECL __wine_msg_wait_objects( DWORD count, const HANDLE *handles,
++                                                const LARGE_INTEGER *timeout, DWORD mask, DWORD flags );
+ 
+ /* Uxtheme hook functions and struct */
+ 
+-- 
+2.38.1
+

--- a/custompatches/0002-winex11.drv-Add-OpenGL-latency-reduction-code.patch
+++ b/custompatches/0002-winex11.drv-Add-OpenGL-latency-reduction-code.patch
@@ -1,0 +1,425 @@
+From 493e0bfa2cc30f2240f591a82d7281fda424b1f2 Mon Sep 17 00:00:00 2001
+From: Torge Matthies <openglfreak@googlemail.com>
+Date: Sun, 3 Jul 2022 15:54:01 +0200
+Subject: [PATCH 2/2] winex11.drv: Add OpenGL latency reduction code.
+
+---
+ dlls/winex11.drv/opengl.c | 274 ++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 261 insertions(+), 13 deletions(-)
+
+diff --git a/dlls/winex11.drv/opengl.c b/dlls/winex11.drv/opengl.c
+index 2acf9db5372c..0ff5c43a1645 100644
+--- a/dlls/winex11.drv/opengl.c
++++ b/dlls/winex11.drv/opengl.c
+@@ -42,6 +42,8 @@
+ #include "xcomposite.h"
+ #include "winternl.h"
+ #include "wine/debug.h"
++#include "wine/server.h"
++#include "../win32u/ntuser_private.h"
+ 
+ #ifdef SONAME_LIBGL
+ 
+@@ -176,6 +178,8 @@ typedef XID GLXPbuffer;
+ #define GLX_RENDERER_ID_MESA              0x818E
+ /** GLX_NV_float_buffer */
+ #define GLX_FLOAT_COMPONENTS_NV           0x20B0
++/** GLX_EXT_swap_control */
++/*#define GLX_SWAP_INTERVAL_EXT             0x20F1*/
+ 
+ 
+ static char *glExtensions;
+@@ -218,6 +222,8 @@ enum dc_gl_type
+     DC_GL_PBUFFER     /* pseudo memory DC using a PBuffer */
+ };
+ 
++typedef LONGLONG rtime_t;
++
+ struct gl_drawable
+ {
+     LONG                           ref;          /* reference count */
+@@ -230,6 +236,11 @@ struct gl_drawable
+     int                            swap_interval;
+     BOOL                           refresh_swap_interval;
+     BOOL                           mutable_pf;
++    rtime_t                        last_swap_time;   /* last exit of wglSwapBuffers, 0 if unknown */
++    rtime_t                        last_vblank_time; /* last known vblank time, 0 if unknown */
++    BOOL                           previous_frame_synchronized; /* whether the previous frame synchronized to vblank */
++    rtime_t                        frame_time;       /* time needed to render a frame, 0 if unknown */
++    rtime_t                        vblank_interval;  /* time between vblanks, 0 if unknown */
+ };
+ 
+ struct wgl_pbuffer
+@@ -526,7 +537,7 @@ static BOOL X11DRV_WineGL_InitOpenglInfo(void)
+ done:
+     if(vis) XFree(vis);
+     if(ctx) {
+-        pglXMakeCurrent(gdi_display, None, NULL);    
++        pglXMakeCurrent(gdi_display, None, NULL);
+         pglXDestroyContext(gdi_display, ctx);
+     }
+     if (win != root) XDestroyWindow( gdi_display, win );
+@@ -744,7 +755,7 @@ static const char *debugstr_fbconfig( GLXFBConfig fbconfig )
+ 
+ static int ConvertAttribWGLtoGLX(const int* iWGLAttr, int* oGLXAttr, struct wgl_pbuffer* pbuf) {
+   int nAttribs = 0;
+-  unsigned cur = 0; 
++  unsigned cur = 0;
+   int attr, pop;
+   int drawattrib = 0;
+   int nvfloatattrib = GLX_DONT_CARE;
+@@ -808,7 +819,7 @@ static int ConvertAttribWGLtoGLX(const int* iWGLAttr, int* oGLXAttr, struct wgl_
+       case WGL_TYPE_RGBA_FLOAT_ATI: pixelattrib = GLX_RGBA_FLOAT_BIT; break ;
+       case WGL_TYPE_RGBA_UNSIGNED_FLOAT_EXT: pixelattrib = GLX_RGBA_UNSIGNED_FLOAT_BIT_EXT; break ;
+       default:
+-        ERR("unexpected PixelType(%x)\n", pop);	
++        ERR("unexpected PixelType(%x)\n", pop);
+       }
+       break;
+ 
+@@ -917,7 +928,7 @@ static int ConvertAttribWGLtoGLX(const int* iWGLAttr, int* oGLXAttr, struct wgl_
+     case WGL_BIND_TO_TEXTURE_RECTANGLE_FLOAT_RG_NV:
+     case WGL_BIND_TO_TEXTURE_RECTANGLE_FLOAT_RGB_NV:
+     case WGL_BIND_TO_TEXTURE_RECTANGLE_FLOAT_RGBA_NV:
+-      /** cannot be converted, see direct handling on 
++      /** cannot be converted, see direct handling on
+        *   - wglGetPixelFormatAttribivARB
+        *  TODO: wglChoosePixelFormat
+        */
+@@ -2157,7 +2168,7 @@ static struct wgl_pbuffer *X11DRV_wglCreatePbufferARB( HDC hdc, int iPixelFormat
+     object->fmt = fmt;
+ 
+     PUSH2(attribs, GLX_PBUFFER_WIDTH,  iWidth);
+-    PUSH2(attribs, GLX_PBUFFER_HEIGHT, iHeight); 
++    PUSH2(attribs, GLX_PBUFFER_HEIGHT, iHeight);
+     while (piAttribList && 0 != *piAttribList) {
+         int attr_v;
+         switch (*piAttribList) {
+@@ -2704,7 +2715,7 @@ static BOOL X11DRV_wglGetPixelFormatAttribivARB( HDC hdc, int iPixelFormat, int
+                 continue;
+ 
+             case WGL_SUPPORT_OPENGL_ARB:
+-                piValues[i] = GL_TRUE; 
++                piValues[i] = GL_TRUE;
+                 continue;
+ 
+             case WGL_ACCELERATION_ARB:
+@@ -2752,14 +2763,14 @@ static BOOL X11DRV_wglGetPixelFormatAttribivARB( HDC hdc, int iPixelFormat, int
+             case WGL_BIND_TO_TEXTURE_RGBA_ARB:
+                 if (!use_render_texture_emulation) {
+                     piValues[i] = GL_FALSE;
+-                    continue;	
++                    continue;
+                 }
+                 curGLXAttr = GLX_RENDER_TYPE;
+                 if (!fmt) goto pix_error;
+                 hTest = pglXGetFBConfigAttrib(gdi_display, fmt->fbconfig, curGLXAttr, &tmp);
+                 if (hTest) goto get_error;
+                 if (GLX_COLOR_INDEX_BIT == tmp) {
+-                    piValues[i] = GL_FALSE;  
++                    piValues[i] = GL_FALSE;
+                     continue;
+                 }
+                 hTest = pglXGetFBConfigAttrib(gdi_display, fmt->fbconfig, GLX_DRAWABLE_TYPE, &tmp);
+@@ -2914,8 +2925,8 @@ static BOOL X11DRV_wglGetPixelFormatAttribivARB( HDC hdc, int iPixelFormat, int
+             hTest = pglXGetFBConfigAttrib(gdi_display, fmt->fbconfig, curGLXAttr, piValues + i);
+             if (hTest) goto get_error;
+             curGLXAttr = 0;
+-        } else { 
+-            piValues[i] = GL_FALSE; 
++        } else {
++            piValues[i] = GL_FALSE;
+         }
+     }
+     return GL_TRUE;
+@@ -3313,6 +3324,130 @@ static void X11DRV_WineGL_LoadExtensions(void)
+     }
+ }
+ 
++static inline BOOL allow_latency_reduction( void )
++{
++    static int status = -1;
++    if (status == -1)
++    {
++        const char *env = getenv( "WINE_OPENGL_LATENCY_REDUCTION" );
++        status = !!(env && atoi(env));
++    }
++    return status == 1;
++}
++
++#define TICKSPERSEC 10000000
++
++typedef struct ftime_t {
++    LONGLONG time;
++    ULONGLONG freq;
++} ftime_t;
++
++static inline ftime_t current_ftime( void )
++{
++    LARGE_INTEGER counter, freq;
++    ftime_t ret;
++    NtQueryPerformanceCounter( &counter, &freq );
++    ret.time = counter.QuadPart;
++    ret.freq = (ULONGLONG)freq.QuadPart;
++    return ret;
++}
++
++static inline rtime_t ftime_to_rtime( ftime_t ftime, BOOL round_up )
++{
++    ftime.time *= TICKSPERSEC;
++    if (round_up)
++        ftime.time += ftime.freq - 1;
++    return ftime.time / ftime.freq;
++}
++
++static inline rtime_t current_rtime( BOOL round_up )
++{
++    return ftime_to_rtime( current_ftime(), round_up );
++}
++
++static rtime_t get_vblank_interval( HWND hwnd )
++{
++    HMONITOR monitor;
++    UNICODE_STRING device_name;
++    MONITORINFOEXW moninfo = { sizeof(MONITORINFOEXW) };
++    DEVMODEW devmode = { {0}, 0, 0, sizeof(DEVMODEW) };
++
++    monitor = NtUserMonitorFromWindow( hwnd, MONITOR_DEFAULTTONEAREST );
++    if (!monitor || !NtUserGetMonitorInfo( monitor, (MONITORINFO*)&moninfo ))
++        return 0;
++
++    RtlInitUnicodeString( &device_name, moninfo.szDevice );
++    if (!NtUserEnumDisplaySettings( &device_name, ENUM_CURRENT_SETTINGS, &devmode, 0 )
++        || devmode.dmDisplayFrequency <= 1)
++        return 0;
++    MESSAGE("detected display frequency: %u\n", devmode.dmDisplayFrequency);
++    return TICKSPERSEC / devmode.dmDisplayFrequency;
++}
++
++#define FRAMETIME_MARGIN_SHIFT 2
++
++static inline rtime_t frame_time_with_margin( rtime_t frame_time )
++{
++    return frame_time + (frame_time >> FRAMETIME_MARGIN_SHIFT) + 3500;
++}
++
++static void get_swap_interval(GLXDrawable drawable, int *interval)
++{
++    /* HACK: does not work correctly with __GL_SYNC_TO_VBLANK */
++    /*pglXQueryDrawable(gdi_display, gl->drawable, GLX_SWAP_INTERVAL_EXT, (unsigned int*)interval);*/
++    *interval = 0;
++}
++
++#define WAIT_MASK (QS_MOUSEBUTTON | QS_KEY | QS_SENDMESSAGE | QS_TIMER | QS_HOTKEY)
++
++static void msg_wait( const LARGE_INTEGER *timeout )
++{
++    LARGE_INTEGER to = *timeout, to2 = to;
++    rtime_t start, end;
++    DWORD ret;
++
++    /* HACK: __wine_msg_wait_objects likes to wait for about 1 ms too long */
++
++    if (to2.QuadPart < 0)
++    {
++        to2.QuadPart += 10000;
++        if (to2.QuadPart >= 0)
++        {
++            end = current_rtime( TRUE );
++            goto busy_loop;
++        }
++    }
++    else if (to2.QuadPart >= 10000)
++        to2.QuadPart -= 10000;
++
++    if (to2.QuadPart >= 0)
++    {
++        __wine_msg_wait_objects( 0, NULL, &to2, WAIT_MASK, MWMO_INPUTAVAILABLE );
++        return;
++    }
++
++again:
++    start = current_rtime( FALSE );
++    ret = __wine_msg_wait_objects( 0, NULL, &to2, WAIT_MASK, MWMO_INPUTAVAILABLE );
++    if (ret == WAIT_OBJECT_0)
++        return;
++    end = current_rtime( TRUE );
++
++    to.QuadPart += end - start;
++    if (to.QuadPart < -11000)
++    {
++        to2.QuadPart = to.QuadPart + 10000;
++        goto again;
++    }
++
++busy_loop:
++    if (to.QuadPart < -1000)
++    {
++        end = end - to.QuadPart - 1000;
++        while (current_rtime( TRUE ) < end)
++            YieldProcessor();
++    }
++}
+ 
+ /**
+  * glxdrv_SwapBuffers
+@@ -3326,6 +3461,11 @@ static BOOL WINAPI glxdrv_wglSwapBuffers( HDC hdc )
+     struct wgl_context *ctx = NtCurrentTeb()->glContext;
+     INT64 ust, msc, sbc, target_sbc = 0;
+ 
++    BOOL enable_latency_reduction = FALSE;
++    BOOL synchronize_to_vblank = FALSE;
++    rtime_t frame_end_time;
++    rtime_t next_vblank_time = 0;
++
+     TRACE("(%p)\n", hdc);
+ 
+     escape.code = X11DRV_FLUSH_GL_DRAWABLE;
+@@ -3338,18 +3478,78 @@ static BOOL WINAPI glxdrv_wglSwapBuffers( HDC hdc )
+         return FALSE;
+     }
+ 
++    if (allow_latency_reduction())
++        enable_latency_reduction = gl->type == DC_GL_WINDOW
++            || gl->type == DC_GL_CHILD_WIN || gl->type == DC_GL_PIXMAP_WIN;
++
++    if (enable_latency_reduction)
++    {
++        if (ctx && (gl->type == DC_GL_WINDOW || gl->type == DC_GL_CHILD_WIN
++                    || gl->type == DC_GL_PIXMAP_WIN))
++            sync_context( ctx );
++        pglFinish();
++        frame_end_time = current_rtime( TRUE );
++    }
++
+     pthread_mutex_lock( &context_mutex );
+-    if (gl->refresh_swap_interval)
++
++    if (enable_latency_reduction)
++    {
++        if (!gl->vblank_interval)
++        {
++            HWND hwnd = 0;
++            assert(!XFindContext( gdi_display, gl->window, winContext, (char **)&hwnd ));
++            assert(hwnd);
++            gl->vblank_interval = get_vblank_interval( hwnd );
++            assert(gl->vblank_interval);
++        }
++
++        if (gl->last_vblank_time)
++        {
++            next_vblank_time = gl->last_vblank_time + gl->vblank_interval;
++            while (next_vblank_time < frame_end_time)
++                next_vblank_time += gl->vblank_interval;
++        }
++
++        if (gl->last_swap_time)
++        {
++            rtime_t new_frame_time = frame_end_time - gl->last_swap_time;
++            if (new_frame_time >= gl->frame_time)
++                gl->frame_time = new_frame_time;
++            else if (gl->frame_time > new_frame_time * 3)
++                gl->frame_time = frame_time_with_margin( new_frame_time );
++            else
++                gl->frame_time = (gl->frame_time * 20 + new_frame_time) / 21;
++        }
++
++        if (frame_end_time - gl->last_vblank_time >= TICKSPERSEC
++            || (!gl->refresh_swap_interval && next_vblank_time - frame_end_time <= frame_time_with_margin( gl->frame_time )))
++            synchronize_to_vblank = TRUE;
++    }
++
++    if (synchronize_to_vblank)
++    {
++        if (!gl->previous_frame_synchronized)
++        {
++            get_swap_interval(gl->drawable, &gl->swap_interval);
++            if (!set_swap_interval(gl->drawable, 1))
++                synchronize_to_vblank = FALSE;
++            gl->previous_frame_synchronized = TRUE;
++        }
++    }
++    else if (gl->refresh_swap_interval || gl->previous_frame_synchronized)
+     {
+         set_swap_interval(gl->drawable, gl->swap_interval);
+         gl->refresh_swap_interval = FALSE;
++        gl->previous_frame_synchronized = FALSE;
+     }
++
+     pthread_mutex_unlock( &context_mutex );
+ 
+     switch (gl->type)
+     {
+     case DC_GL_PIXMAP_WIN:
+-        if (ctx) sync_context( ctx );
++        if (!enable_latency_reduction && ctx) sync_context( ctx );
+         escape.gl_drawable = gl->pixmap;
+         if (pglXCopySubBufferMESA) {
+             /* (glX)SwapBuffers has an implicit glFlush effect, however
+@@ -3370,7 +3570,7 @@ static BOOL WINAPI glxdrv_wglSwapBuffers( HDC hdc )
+         break;
+     case DC_GL_WINDOW:
+     case DC_GL_CHILD_WIN:
+-        if (ctx) sync_context( ctx );
++        if (!enable_latency_reduction && ctx) sync_context( ctx );
+         if (gl->type == DC_GL_CHILD_WIN) escape.gl_drawable = gl->window;
+         /* fall through */
+     default:
+@@ -3387,6 +3587,54 @@ static BOOL WINAPI glxdrv_wglSwapBuffers( HDC hdc )
+     if (escape.gl_drawable && pglXWaitForSbcOML)
+         pglXWaitForSbcOML( gdi_display, gl->drawable, target_sbc, &ust, &msc, &sbc );
+ 
++    if (enable_latency_reduction)
++    {
++        rtime_t current_time = current_rtime( FALSE );
++
++        if (!synchronize_to_vblank && gl->last_vblank_time && gl->frame_time)
++        {
++            LARGE_INTEGER timeout;
++
++            next_vblank_time = gl->last_vblank_time + gl->vblank_interval;
++            while (next_vblank_time < current_time + frame_time_with_margin( gl->frame_time ))
++                next_vblank_time += gl->vblank_interval;
++
++            timeout.QuadPart = -(next_vblank_time - frame_time_with_margin( gl->frame_time ) - current_time);
++            if (timeout.QuadPart < 0 && -timeout.QuadPart < TICKSPERSEC)
++                msg_wait( &timeout );
++
++            current_time = current_rtime( FALSE );
++        }
++
++        pthread_mutex_lock( &context_mutex );
++
++        gl->last_swap_time = current_time;
++        if (synchronize_to_vblank)
++            gl->last_vblank_time = current_time;
++
++        pthread_mutex_unlock( &context_mutex );
++
++        if (synchronize_to_vblank && gl->frame_time)
++        {
++            LARGE_INTEGER timeout;
++
++            next_vblank_time = gl->last_vblank_time + gl->vblank_interval;
++            while (next_vblank_time < current_time + frame_time_with_margin( gl->frame_time ))
++                next_vblank_time += gl->vblank_interval;
++
++            timeout.QuadPart = -(next_vblank_time - frame_time_with_margin( gl->frame_time ) - current_time);
++            if (timeout.QuadPart < 0 && -timeout.QuadPart < TICKSPERSEC)
++            {
++                msg_wait( &timeout );
++
++                current_time = current_rtime( FALSE );
++                pthread_mutex_lock( &context_mutex );
++                gl->last_swap_time = current_time;
++                pthread_mutex_unlock( &context_mutex );
++            }
++        }
++    }
++
+     release_gl_drawable( gl );
+ 
+     if (escape.gl_drawable)
+-- 
+2.38.1
+

--- a/custompatches/9989-misc-ps0126-devenum-Register-IEEE-float-for-Direct-Sound-defau.patch
+++ b/custompatches/9989-misc-ps0126-devenum-Register-IEEE-float-for-Direct-Sound-defau.patch
@@ -1,0 +1,36 @@
+commit d444330ed7685686f46db7fb8ed1ad0cbec72c7b
+Author: Rémi Bernon <rbernon@codeweavers.com>
+Date:   Wed Jun 16 17:36:15 2021 +0200
+Subject: [PATCH] devenum: Register IEEE float for Direct Sound default device.
+
+--
+diff --git a/dlls/devenum/createdevenum.c b/dlls/devenum/createdevenum.c
+index 8e9cf56eb09..97855b12b81 100644
+--- a/dlls/devenum/createdevenum.c
++++ b/dlls/devenum/createdevenum.c
+@@ -481,7 +481,7 @@ static BOOL CALLBACK register_dsound_devices(GUID *guid, const WCHAR *desc, cons
+     static const WCHAR defaultW[] = L"Default DirectSound Device";
+     IPropertyBag *prop_bag = NULL;
+     REGFILTERPINS2 rgpins = {0};
+-    REGPINTYPES rgtypes = {0};
++    REGPINTYPES rgtypes[2] = {};
+     REGFILTER2 rgf = {0};
+     WCHAR clsid[CHARS_IN_GUID];
+     VARIANT var;
+@@ -512,10 +512,12 @@ static BOOL CALLBACK register_dsound_devices(GUID *guid, const WCHAR *desc, cons
+     rgf.rgPins2 = &rgpins;
+     rgpins.dwFlags = REG_PINFLAG_B_RENDERER;
+     /* FIXME: native registers many more formats */
+-    rgpins.nMediaTypes = 1;
+-    rgpins.lpMediaType = &rgtypes;
+-    rgtypes.clsMajorType = &MEDIATYPE_Audio;
+-    rgtypes.clsMinorType = &MEDIASUBTYPE_PCM;
++    rgpins.nMediaTypes = 2;
++    rgpins.lpMediaType = rgtypes;
++    rgtypes[0].clsMajorType = &MEDIATYPE_Audio;
++    rgtypes[0].clsMinorType = &MEDIASUBTYPE_PCM;
++    rgtypes[1].clsMajorType = &MEDIATYPE_Audio;
++    rgtypes[1].clsMinorType = &MEDIASUBTYPE_IEEE_FLOAT;
+ 
+     write_filter_data(prop_bag, &rgf);
+ 

--- a/custompatches/9989-misc-ps0171-server-Don-t-wait-for-low-level-hook-result-when-q.patch
+++ b/custompatches/9989-misc-ps0171-server-Don-t-wait-for-low-level-hook-result-when-q.patch
@@ -1,0 +1,60 @@
+From: Piotr Caban <piotr@codeweavers.com>
+Subject: [PATCH v2] server: Don't wait for low level hook result when queuing hardware message.
+Message-Id: <daf382d3-924e-7c33-c876-5b8d6298c137@codeweavers.com>
+Date: Tue, 21 Sep 2021 15:51:35 +0200
+
+
+Without the change graphic drivers are blocking until low level hooks
+are processed when injecting keyboard and mouse events. Causes 2-seconds 
+(timeout) freeze in GtaV.
+
+Signed-off-by: Piotr Caban <piotr@codeweavers.com>
+---
+v2:
+  - don't specify sender in send_hook_ll_message to avoid queuing result
+
+  server/queue.c | 16 +++++++++++++---
+  1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/server/queue.c b/server/queue.c
+index e4903bcb79f..5c19348eeba 100644
+--- a/server/queue.c
++++ b/server/queue.c
+@@ -1839,7 +1839,12 @@ static int queue_mouse_message( struct desktop *desktop, user_handle_t win, cons
+         /* specify a sender only when sending the last message */
+         if (!(flags & ((1 << ARRAY_SIZE( messages )) - 1)))
+         {
+-            if (!(wait = send_hook_ll_message( desktop, msg, input, sender )))
++            if (origin == IMO_HARDWARE)
++            {
++                if (!send_hook_ll_message( desktop, msg, input, NULL ))
++                    queue_hardware_message( desktop, msg, 0 );
++            }
++            else if (!(wait = send_hook_ll_message( desktop, msg, input, sender )))
+                 queue_hardware_message( desktop, msg, 0 );
+         }
+         else if (!send_hook_ll_message( desktop, msg, input, NULL ))
+@@ -1860,7 +1865,7 @@ static int queue_keyboard_message( struct desktop *desktop, user_handle_t win, c
+     struct thread *foreground;
+     unsigned char vkey = input->kbd.vkey;
+     unsigned int message_code, time;
+-    int wait;
++    int wait = 0;
+ 
+     if (!(time = input->kbd.time)) time = get_tick_count();
+ 
+@@ -1981,7 +1986,12 @@ static int queue_keyboard_message( struct desktop *desktop, user_handle_t win, c
+         msg_data->flags |= (flags & (KF_EXTENDED | KF_ALTDOWN | KF_UP)) >> 8;
+     }
+ 
+-    if (!(wait = send_hook_ll_message( desktop, msg, input, sender )))
++    if (origin == IMO_HARDWARE)
++    {
++        if (!send_hook_ll_message( desktop, msg, input, NULL ))
++            queue_hardware_message( desktop, msg, 1 );
++    }
++    else if (!(wait = send_hook_ll_message( desktop, msg, input, sender )))
+         queue_hardware_message( desktop, msg, 1 );
+ 
+     return wait;
+

--- a/custompatches/9999-diffs-8bpp-copy-support.patch
+++ b/custompatches/9999-diffs-8bpp-copy-support.patch
@@ -1,0 +1,55 @@
+diff --git a/dlls/windowscodecs/converter.c b/dlls/windowscodecs/converter.c
+index 11111111111..11111111111 100644
+--- a/dlls/windowscodecs/converter.c
++++ b/dlls/windowscodecs/converter.c
+@@ -1034,6 +1034,50 @@ static HRESULT copypixels_to_24bppBGR(struct FormatConverter *This, const WICRec
+ 
+     switch (source_format)
+     {
++    case format_8bppGray:
++        if (prc)
++        {
++            HRESULT res;
++            INT x, y;
++            BYTE *srcdata;
++            UINT srcstride, srcdatasize;
++            const BYTE *srcrow;
++            const BYTE *srcbyte;
++            BYTE *dstrow;
++            BYTE *dstpixel;
++
++            srcstride = prc->Width;
++            srcdatasize = srcstride * prc->Height;
++
++            srcdata = HeapAlloc(GetProcessHeap(), 0, srcdatasize);
++            if (!srcdata) return E_OUTOFMEMORY;
++
++            res = IWICBitmapSource_CopyPixels(This->source, prc, srcstride, srcdatasize, srcdata);
++
++            if (SUCCEEDED(res))
++            {
++                srcrow = srcdata;
++                dstrow = pbBuffer;
++                for (y=0; y<prc->Height; y++) {
++                    srcbyte = srcrow;
++                    dstpixel = dstrow;
++                    for (x=0; x<prc->Width; x++)
++                    {
++                        *dstpixel++ = *srcbyte;
++                        *dstpixel++ = *srcbyte;
++                        *dstpixel++ = *srcbyte;
++                        srcbyte++;
++                    }
++                    srcrow += srcstride;
++                    dstrow += cbStride;
++                }
++            }
++
++            HeapFree(GetProcessHeap(), 0, srcdata);
++
++            return res;
++        }
++        return S_OK;
+     case format_24bppBGR:
+     case format_24bppRGB:
+         if (prc)

--- a/custompatches/9999-diffs-hide-wine-version.patch
+++ b/custompatches/9999-diffs-hide-wine-version.patch
@@ -1,0 +1,54 @@
+diff --git a/dlls/kernel32/module.c b/dlls/kernel32/module.c
+index 11111111111..11111111111 100644
+--- a/dlls/kernel32/module.c
++++ b/dlls/kernel32/module.c
+@@ -262,6 +262,34 @@ BOOL WINAPI GetBinaryTypeA( LPCSTR lpApplicationName, LPDWORD lpBinaryType )
+     return GetBinaryTypeW(NtCurrentTeb()->StaticUnicodeString.Buffer, lpBinaryType);
+ }
+
++static BOOL block_wine_get_version = FALSE;
++
++BOOL CALLBACK init_block_wine_get_version( INIT_ONCE* init_once, PVOID param, PVOID *ctx )
++{
++    WCHAR *buffer;
++    DWORD size;
++
++    if ((size = GetEnvironmentVariableW( L"WINE_BLOCK_GET_VERSION", NULL, 0 )))
++    {
++        if (!(buffer = HeapAlloc( GetProcessHeap(), 0, sizeof(*buffer) * size )))
++        {
++            ERR("No memory.\n");
++            return FALSE;
++        }
++
++        if (GetEnvironmentVariableW( L"WINE_BLOCK_GET_VERSION", buffer, size ) != size - 1)
++        {
++            ERR("Error getting WINE_BLOCK_GET_VERSION env variable.\n");
++            return FALSE;
++        }
++
++        block_wine_get_version = *buffer && !!wcsncmp( buffer, L"0", 1 );
++
++        HeapFree( GetProcessHeap(), 0, buffer );
++    }
++    return TRUE;
++}
++
+ /***********************************************************************
+  *           GetProcAddress   		(KERNEL32.@)
+  *
+@@ -279,6 +307,14 @@ FARPROC get_proc_address( HMODULE hModule, LPCSTR function )
+ {
+     FARPROC     fp;
+
++    if ((ULONG_PTR)function >> 16)
++    {
++        static INIT_ONCE init_once = INIT_ONCE_STATIC_INIT;
++        InitOnceExecuteOnce( &init_once, init_block_wine_get_version, NULL, NULL );
++        if (block_wine_get_version && !strncmp( function, "wine_get_version", 16 ))
++            return NULL;
++    }
++
+     if (!hModule) hModule = NtCurrentTeb()->Peb->ImageBaseAddress;
+
+     if ((ULONG_PTR)function >> 16)

--- a/custompatches/9999-diffs-thread-characteristic-audio-priority.patch
+++ b/custompatches/9999-diffs-thread-characteristic-audio-priority.patch
@@ -1,0 +1,14 @@
+diff --git a/dlls/avrt/main.c b/dlls/avrt/main.c
+index abcf0ab68ab..f85b76fc1be 100644
+--- a/dlls/avrt/main.c
++++ b/dlls/avrt/main.c
+@@ -71,6 +71,9 @@ HANDLE WINAPI AvSetMmThreadCharacteristicsW(const WCHAR *name, DWORD *index)
+         return NULL;
+     }
+ 
++    if (!wcscmp(name, L"Audio") || !wcscmp(name, L"Pro Audio"))
++        SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
++
+     return (HANDLE)0x12345678;
+ }
+ 

--- a/custompatches/9999-diffs-use-clock_nanosleep-for-delay.patch
+++ b/custompatches/9999-diffs-use-clock_nanosleep-for-delay.patch
@@ -1,0 +1,46 @@
+diff --git a/dlls/ntdll/unix/sync.c b/dlls/ntdll/unix/sync.c
+index e303367c29f..3723d21f885 100644
+--- a/dlls/ntdll/unix/sync.c
++++ b/dlls/ntdll/unix/sync.c
+@@ -2788,10 +2788,39 @@ NTSTATUS WINAPI NtDelayExecution( BOOLEAN alertable, const LARGE_INTEGER *timeou
+     }
+     else
+     {
++        LONGLONG ticks = timeout->QuadPart;
+         LARGE_INTEGER now;
+-        timeout_t when, diff;
++        timeout_t when = ticks, diff;
+ 
+-        if ((when = timeout->QuadPart) < 0)
++#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_NANOSLEEP)
++        static BOOL disable_clock_nanosleep = FALSE;
++        if (!disable_clock_nanosleep && ticks != 0)
++        {
++            struct timespec when;
++            int err;
++
++            if (ticks < 0)
++            {
++                clock_gettime( CLOCK_REALTIME, &when );
++                when.tv_sec += (time_t)(-ticks / TICKSPERSEC);
++                when.tv_nsec += (long)((-ticks % TICKSPERSEC) * 100);
++            }
++            else
++            {
++                when.tv_sec = (time_t)((ticks / TICKSPERSEC) - SECS_1601_TO_1970);
++                when.tv_nsec = (long)((ticks % TICKSPERSEC) * 100);
++            }
++
++            usleep(0);
++            while ((err = clock_nanosleep( CLOCK_REALTIME, TIMER_ABSTIME, &when, NULL )) == EINTR);
++            if (!err)
++                return STATUS_SUCCESS;
++            else
++                disable_clock_nanosleep = TRUE;
++        }
++#endif
++
++        if (when < 0)
+         {
+             NtQuerySystemTime( &now );
+             when = now.QuadPart - when;

--- a/custompatches/nvidia-xrandr-fix.patch
+++ b/custompatches/nvidia-xrandr-fix.patch
@@ -1,0 +1,26 @@
+--- a/dlls/winex11.drv/xrandr.c
++++ b/dlls/winex11.drv/xrandr.c
+@@ -378,7 +375,6 @@
+     XRRScreenResources *screen_resources;
+     XRROutputInfo *output_info;
+     XRRModeInfo *first_mode;
+-    INT major, event, error;
+     INT output_idx, i, j;
+     BOOL only_one_mode;
+ 
+@@ -429,15 +425,6 @@
+ 
+         if (!only_one_mode)
+             continue;
+-
+-        /* Check if it is NVIDIA proprietary driver */
+-        if (XQueryExtension( gdi_display, "NV-CONTROL", &major, &event, &error ))
+-        {
+-            ERR_(winediag)("Broken NVIDIA RandR detected, falling back to RandR 1.0. "
+-                           "Please consider using the Nouveau driver instead.\n");
+-            pXRRFreeScreenResources( screen_resources );
+-            return TRUE;
+-        }
+     }
+     pXRRFreeScreenResources( screen_resources );
+     return FALSE;

--- a/custompatches/ps0387-ntdll-Implement-NtFlushProcessWriteBuffers.patch
+++ b/custompatches/ps0387-ntdll-Implement-NtFlushProcessWriteBuffers.patch
@@ -1,0 +1,74 @@
+From 5fbb45baf9036a17b0ebbaa388670637ecd3cebf Mon Sep 17 00:00:00 2001
+From: Torge Matthies <openglfreak@googlemail.com>
+Date: Sat, 26 Mar 2022 00:24:14 +0100
+Subject: [PATCH] ntdll: Implement NtFlushProcessWriteBuffers.
+
+---
+ configure.ac              |  1 +
+ dlls/ntdll/unix/server.c  | 12 ++++++++++++
+ dlls/ntdll/unix/virtual.c | 10 ----------
+ 3 files changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 11111111111..11111111111 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -455,6 +455,7 @@ AC_CHECK_HEADERS(\
+ 	linux/input.h \
+ 	linux/ioctl.h \
+ 	linux/major.h \
++	linux/membarrier.h \
+ 	linux/param.h \
+ 	linux/seccomp.h \
+ 	linux/serial.h \
+diff --git a/dlls/ntdll/unix/server.c b/dlls/ntdll/unix/server.c
+index 11111111111..11111111111 100644
+--- a/dlls/ntdll/unix/server.c
++++ b/dlls/ntdll/unix/server.c
+@@ -53,6 +53,9 @@
+ #ifdef HAVE_LINUX_IOCTL_H
+ #include <linux/ioctl.h>
+ #endif
++#ifdef HAVE_LINUX_MEMBARRIER_H
++#include <linux/membarrier.h>
++#endif
+ #ifdef HAVE_SYS_PRCTL_H
+ # include <sys/prctl.h>
+ #endif
+@@ -1849,3 +1852,12 @@ NTSTATUS WINAPI NtClose( HANDLE handle )
+     }
+     return ret;
+ }
++
++
++/**********************************************************************
++ *           NtFlushProcessWriteBuffers  (NTDLL.@)
++ */
++void WINAPI NtFlushProcessWriteBuffers(void)
++{
++    syscall( __NR_membarrier, MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0, 0 );
++}
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 11111111111..11111111111 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -5412,16 +5412,6 @@ NTSTATUS WINAPI NtFlushInstructionCache( HANDLE handle, const void *addr, SIZE_T
+ }
+ 
+ 
+-/**********************************************************************
+- *           NtFlushProcessWriteBuffers  (NTDLL.@)
+- */
+-void WINAPI NtFlushProcessWriteBuffers(void)
+-{
+-    static int once = 0;
+-    if (!once++) FIXME( "stub\n" );
+-}
+-
+-
+ /**********************************************************************
+  *           NtCreatePagingFile  (NTDLL.@)
+  */
+-- 
+2.36.1
+

--- a/custompatches/winepulse-gonX-v6.11-0002-5.14-Latency-Fix.patch
+++ b/custompatches/winepulse-gonX-v6.11-0002-5.14-Latency-Fix.patch
@@ -1,0 +1,60 @@
+From 4a2c23db4eddd827ac81513af43bc92475ad7d3a Mon Sep 17 00:00:00 2001
+From: Sebastian 'gonX' Jensen <gonx@gonx.dk>
+Date: Sun, 20 Jun 2021 17:02:15 +0200
+Subject: [PATCH 2/2] 5.14 Latency Fix
+
+---
+ dlls/winepulse.drv/mmdevdrv.c | 22 ++++++++++++++--------
+ 1 file changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/dlls/winepulse.drv/mmdevdrv.c b/dlls/winepulse.drv/mmdevdrv.c
+index 07407089ac5..3ed47e38c83 100644
+--- a/dlls/winepulse.drv/mmdevdrv.c
++++ b/dlls/winepulse.drv/mmdevdrv.c
+@@ -68,9 +68,6 @@ enum DriverPriority {
+     Priority_Preferred
+ };
+ 
+-static const REFERENCE_TIME MinimumPeriod = 30000;
+-static const REFERENCE_TIME DefaultPeriod = 100000;
+-
+ static pa_context *pulse_ctx;
+ static pa_mainloop *pulse_ml;
+ 
+@@ -510,11 +507,12 @@ static void pulse_probe_settings(int render, WAVEFORMATEXTENSIBLE *fmt) {
+     if (length)
+         pulse_def_period[!render] = pulse_min_period[!render] = pa_bytes_to_usec(10 * length, &ss);
+ 
+-    if (pulse_min_period[!render] < MinimumPeriod)
+-        pulse_min_period[!render] = MinimumPeriod;
+-
+-    if (pulse_def_period[!render] < DefaultPeriod)
+-        pulse_def_period[!render] = DefaultPeriod;
++    const char* penv = getenv("STAGING_AUDIO_PERIOD");
++    if (penv) {
++        int val = atoi(penv);
++        pulse_def_period[!render] = pulse_min_period[!render] = val;
++        printf("Staging audio period set to %d.\n", val);
++    }
+ 
+     wfx->wFormatTag = WAVE_FORMAT_EXTENSIBLE;
+     wfx->cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+@@ -1640,6 +1638,14 @@ static HRESULT WINAPI AudioClient_Initialize(IAudioClient2 *iface,
+         if (duration <= 2 * period)
+             period /= 2;
+     }
++
++    const char* denv = getenv("STAGING_AUDIO_DURATION");
++    if (denv) {
++        int val = atoi(denv);
++        duration = val;
++        printf("Staging audio duration set to %d.\n", val);
++    }
++
+     period_bytes = pa_frame_size(&This->ss) * MulDiv(period, This->ss.rate, 10000000);
+ 
+     if (duration < 20000000)
+-- 
+2.32.0
+
+


### PR DESCRIPTION
I moved the patches from the GDrive to the Git repo in the appropriate folder
This helps a lot while trying to reproduce old builds, since GDrive files can be replaced without warning and/or be deleted
