### PR TITLE
features: cachy/valve wine support, switch to DockerHub image

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,9 +1,6 @@
 name: DockerHub Container CI
 
 on:
-  push:
-    branches:
-      - dev
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,31 @@
+name: DockerHub Container CI
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUBNAME }}
+          password: ${{ secrets.DOCKERHUBCI }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: nellokudo/wine-builder:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM main-deps AS manual-deps
 
 ENV FFMPEG_VERSION="7.1.1" \
     LIBXKBCOMMON_VERSION="1.9.2" \
+    GSTREAMER_VERSION="1.22" \
     LLVM_MINGW_VERSION="20250402" \
     XZ_VERSION="5.6.4" \
     LIBUNWIND_VERSION="1.8.1" \
@@ -56,6 +57,22 @@ RUN wget -O libxkbcommon.tar.gz https://github.com/xkbcommon/libxkbcommon/archiv
     meson compile -C "build_i386" xkbcommon:static_library && \
     meson compile -C "build_i386" xkbregistry:static_library && \
     meson install -C "build_i386" --no-rebuild --tags devel
+
+RUN wget -O gstreamer.tar.gz https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/${GSTREAMER_VERSION}/gstreamer-${GSTREAMER_VERSION}.tar.gz && \
+    tar -xf gstreamer.tar.gz && \
+    cd gstreamer-${GSTREAMER_VERSION} && \
+    # 64-bit build
+    echo "[binaries]\nc = 'gcc'\ncpp = 'g++'\n\n[host_machine]\nsystem = 'linux'\ncpu_family = 'x86_64'\ncpu = 'x86_64'\nendian = 'little'" > /opt/build64-conf.txt && \
+    meson setup build_x86_64 --prefix=/usr/local/x86_64 --libdir=/usr/local/x86_64/lib/x86_64-linux-gnu --native-file /opt/build64-conf.txt && \
+    ninja -C build_x86_64 && \
+    ninja -C build_x86_64 install && \
+    rm -rf build_x86_64 && \
+    # 32-bit build
+    echo "[binaries]\nc = 'gcc'\ncpp = 'g++'\n\n[host_machine]\nsystem = 'linux'\ncpu_family = 'x86'\ncpu = 'x86'\nendian = 'little'" > /opt/build32-conf.txt && \
+    meson setup build_i386 --prefix=/usr/local/i386 --libdir=/usr/local/i386/lib/i386-linux-gnu --native-file /opt/build32-conf.txt && \
+    ninja -C build_i386 && \
+    ninja -C build_i386 install && \
+    rm -rf build_i386
 
 RUN wget -O ffmpeg.tar.xz https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz && \
     tar -xf ffmpeg.tar.xz && \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can find prebuilt binaries on the [Releases page](https://github.com/NelloKu
 
 ## Builds description
 
-WineBuilder uses the latest Proton SDK (with a few changes) to build Wine inside a Docker container. This ensures great compatibility and feature completeness — including seamless usage within the **Steam Linux Runtime**.
+WineBuilder uses the latest Proton SDK (with a few changes) to build Wine inside a Docker container. This ensures great compatibility and feature completeness — including seamless usage within the **Steam Linux Runtime**. The `wine-builder` container is hosted [here](https://hub.docker.com/r/nellokudo/wine-builder), built from its apposite [GitHub CI](https://github.com/NelloKudo/WineBuilder/actions/workflows/dockerhub.yml).
 
 By default, the script creates **osu!-specific builds**, with patches from [wine-osu-patches](https://github.com/whrvt/wine-osu-patches), also used in [osu-winello](https://github.com/NelloKudo/osu-winello). 
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,12 @@ Info "Welcome to WineBuilder!"
 
 ## Setting up Docker..
 mkdir -p {custompatches,ccache,output,protonfonts,sources}
-docker buildx build --progress=plain -t wine-builder . || { echo "docker build failed" && exit; }
+
+Info "Pulling Docker image..."
+docker pull nellokudo/wine-builder:latest || { echo "docker pull failed" && exit 1; }
+
+# Or build the image locally from the Dockerfile
+# docker buildx build --progress=plain -t wine-builder . || { echo "docker build failed" && exit; }
 
 ## Allow overriding variables in wine_builder.sh
 vars=(WINE_OSU USE_STAGING USE_TKG BUILD_NAME \

--- a/wine_builder.sh
+++ b/wine_builder.sh
@@ -26,6 +26,12 @@ _configuration() {
     # Toggle to enable/disable Wine-tkg.
     USE_TKG="${USE_TKG:-false}"
 
+    # Toggle to enable/disable Wine-CachyOS.
+    USE_CACHY="${USE_CACHY:-false}"
+
+    # Toggle to enable/disable Wine-Valve.
+    USE_VALVE="${USE_VALVE:-false}"
+
     # Set your custom build name here:
     BUILD_NAME="${BUILD_NAME:-wine-wb}"
 
@@ -53,6 +59,8 @@ _configuration() {
 
     # Other links
     WINE_TKG_URL="https://github.com/Kron4ek/wine-tkg"
+    WINE_CACHY_URL="https://github.com/CachyOS/wine-cachyos"
+    WINE_VALVE_URL="https://github.com/ValveSoftware/wine"
 
     # Patchset configuration: use remote:latest to use latest tag matching tag filter, remote:<tag> to use chosen tag
     PATCHSET="${PATCHSET:-}" # leave empty for loose patches in custompatches/
@@ -69,15 +77,16 @@ _configuration() {
         USE_TKG="false"
     fi
 
-    # tkg-specific settings
-    if [ "$USE_TKG" == "true" ]; then
-        USE_STAGING="false"
-        WINE_URL="$WINE_TKG_URL"
+    # tkg/cachy/valve settings
+    for variant in tkg cachy valve; do
+        use_flag="USE_${variant^^}"
+        url_var="WINE_${variant^^}_URL"
 
-        if [[ "$BUILD_NAME" != *"-tkg" ]]; then
-            BUILD_NAME="$BUILD_NAME-tkg"
+        if [ "${!use_flag}" = "true" ]; then
+            USE_STAGING="false"
+            WINE_URL="${!url_var}"
         fi
-    fi
+    done
 }
 
 ## ------------------------------------------------------------
@@ -95,7 +104,7 @@ _staging_patcher() {
         fi
     else
         # Also disabling problematic Staging patchset
-        STAGING_ARGS+=" -W winedevice-Default_Drivers"
+        STAGING_ARGS+=" -W winedevice-Default_Drivers" || Info "Problematic patchset not found, ignoring.."
     fi
 
     local staging_patcher
@@ -521,14 +530,14 @@ main() {
     git config --global http.lowSpeedLimit 1000
     git config --global http.lowSpeedTime 600
 
-    # Change source name if the WINE_URL isn't the default one (or fallback) to prevent conflicts
-    if [ "$WINE_URL" != "https://github.com/wine-mirror/wine.git" ] && [ "$WINE_URL" != "$WINE_FALLBACK_URL" ]; then
-        # Add check for tkg
-        if [ "$WINE_URL" = "$WINE_TKG_URL" ]; then
-            SOURCE_NAME="wine-tkg"
-        else
-            SOURCE_NAME="wine-custom"
-        fi
+    # Change source name if the WINE_URL isn't the default or fallback one
+    if [[ "$WINE_URL" != "https://github.com/wine-mirror/wine.git" && "$WINE_URL" != "$WINE_FALLBACK_URL" ]]; then
+        case "$WINE_URL" in
+            "$WINE_TKG_URL")    SOURCE_NAME="wine-tkg" ;;
+            "$WINE_CACHY_URL")  SOURCE_NAME="wine-cachy" ;;
+            "$WINE_VALVE_URL")  SOURCE_NAME="wine-valve" ;;
+            *)                  SOURCE_NAME="wine-custom" ;;
+        esac
     fi
 
     # Initialize/update Wine source
@@ -556,8 +565,7 @@ main() {
         git checkout "${WINE_VERSION}" || Error "Failed to checkout Wine version ${WINE_VERSION}"
     else
         Info "Using latest Wine version"
-        git checkout master
-        git pull origin master
+        (git checkout master && git pull origin master) || Info "Master not found for this repository, using default commit.."
     fi
     WINE_VERSION=$(git describe --tags --abbrev=0 | cut -f2 -d'-')
     Info "Building Wine version: ${WINE_VERSION}"
@@ -636,10 +644,13 @@ main() {
         tools/make_specfiles
     }
 
-    chmod +x tools/make_makefiles
-    tools/make_makefiles
-    autoreconf -fiv
+    # Only ask for non-cachy/valve builds
+    if [[ "$USE_CACHY" == "false" && "$USE_VALVE" == "false" ]]; then
+        chmod +x tools/make_makefiles
+        tools/make_makefiles
+    fi
 
+    autoreconf -fiv
     # Build and package
     build_wine
     package_wine


### PR DESCRIPTION
- Added support for wine-cachyos/wine-valve to `wine_builder.sh`
- Added `GStreamer 1.22` to the Dockerfile for Proton's `winegstreamer` to build correctly.
- Added GitHub CI to build and push `wine-builder` docker image to [DockerHub](https://hub.docker.com/r/nellokudo/wine-builder)
- Adjusted build.sh to use the DockerHub image by default.